### PR TITLE
[WIP] Limit PDF/ Print Option to Produce Only One Page

### DIFF
--- a/static/js/vendor/DataTables/datatables.js
+++ b/static/js/vendor/DataTables/datatables.js
@@ -27845,7 +27845,8 @@ DataTable.ext.buttons.pdfHtml5 = {
 
 		var doc = {
 			pageSize: config.pageSize,
-			pageOrientation: config.orientation,
+            maxPagesNumber: 0, 
+			pageOrientation: 'landscape',
 			content: [
 				{
 					table: {
@@ -28054,7 +28055,6 @@ DataTable.ext.buttons.print = {
 		// Open a new window for the printable table
 		var win = window.open( '', '' );
 		var title = config.title.replace( '*', $('title').text() );
-
 		win.document.close();
 
 		// Inject the title and also a copy of the style and link tags from this
@@ -28081,7 +28081,7 @@ DataTable.ext.buttons.print = {
 
 		setTimeout( function () {
 			if ( config.autoPrint ) {
-				win.print(); // blocking - so close will not
+				win.print(true, 0, 0); // blocking - so close will not
 				win.close(); // execute until this is done
 			}
 		}, 250 );

--- a/static/js/vendor/DataTables/datatables.js
+++ b/static/js/vendor/DataTables/datatables.js
@@ -27845,7 +27845,7 @@ DataTable.ext.buttons.pdfHtml5 = {
 
 		var doc = {
 			pageSize: config.pageSize,
-            maxPagesNumber: 0, 
+            maxPagesNumber: 1, 
 			pageOrientation: 'landscape',
 			content: [
 				{

--- a/staticfiles/js/vendor/DataTables/datatables.js
+++ b/staticfiles/js/vendor/DataTables/datatables.js
@@ -27845,7 +27845,8 @@ DataTable.ext.buttons.pdfHtml5 = {
 
 		var doc = {
 			pageSize: config.pageSize,
-			pageOrientation: config.orientation,
+            maxPagesNumber: 0, 
+			pageOrientation: 'landscape',
 			content: [
 				{
 					table: {
@@ -28054,7 +28055,6 @@ DataTable.ext.buttons.print = {
 		// Open a new window for the printable table
 		var win = window.open( '', '' );
 		var title = config.title.replace( '*', $('title').text() );
-
 		win.document.close();
 
 		// Inject the title and also a copy of the style and link tags from this
@@ -28081,7 +28081,7 @@ DataTable.ext.buttons.print = {
 
 		setTimeout( function () {
 			if ( config.autoPrint ) {
-				win.print(); // blocking - so close will not
+				win.print(true, 0, 0); // blocking - so close will not
 				win.close(); // execute until this is done
 			}
 		}, 250 );

--- a/staticfiles/js/vendor/DataTables/datatables.js
+++ b/staticfiles/js/vendor/DataTables/datatables.js
@@ -27845,7 +27845,7 @@ DataTable.ext.buttons.pdfHtml5 = {
 
 		var doc = {
 			pageSize: config.pageSize,
-            maxPagesNumber: 0, 
+            maxPagesNumber: 1, 
 			pageOrientation: 'landscape',
 			content: [
 				{


### PR DESCRIPTION
Per discussion in [#534](https://github.com/OpenSourcePolicyCenter/webapp-public/issues/534), the `Print` button on TaxBrain output page currently produces two pages. See the following screenshot for detail:

![pdf_one_page](https://user-images.githubusercontent.com/13324931/27298053-3351b95c-54f5-11e7-9bf2-78ddd4b23024.png)

I tried different ways to limit the number of pages to print via `DataTable.ext.buttons.pdfHtml5` and `DataTable.ext.buttons.print` functions (details could be found within the commit), but they do not seem to help. 

@brittainhard, could you advice what's the best approach to deal with this issue?