### PR TITLE
Change title name for liability table

### DIFF
--- a/static/js/vendor/DataTables/datatables.js
+++ b/static/js/vendor/DataTables/datatables.js
@@ -28235,7 +28235,7 @@ DataTable.ext.buttons.print = {
 
 		// Inject the table and other surrounding information
 		$(win.document.body).html(
-			'<h1>'+title+'</h1>'+
+			'<h1>'+ 'TOTAL LIABILITIES BY CALENDAR YEAR (CHANGE)' +'</h1>'+
 			'<div>'+config.message+'</div>'+
 			html
 		);

--- a/staticfiles/js/vendor/DataTables/datatables.js
+++ b/staticfiles/js/vendor/DataTables/datatables.js
@@ -28235,7 +28235,7 @@ DataTable.ext.buttons.print = {
 
 		// Inject the table and other surrounding information
 		$(win.document.body).html(
-			'<h1>'+title+'</h1>'+
+			'<h1>'+ 'TOTAL LIABILITIES BY CALENDAR YEAR (CHANGE)' +'</h1>'+
 			'<div>'+config.message+'</div>'+
 			html
 		);


### PR DESCRIPTION
Per requests in #545, the title name for liability table is not right when user exports the table via "Print" button. 

Beforehand, the title name was "Welcome to TaxBrain". After this PR, the title name, when being printed, would be more informative, that is also consistent with the title name on the result page. 

The new page generated from the "Print" button for liability table will look like:

![screen shot 2017-08-15 at 11 51 44 am](https://user-images.githubusercontent.com/13324931/29324927-e0cad8ee-81b3-11e7-87d7-8864998e7b39.png)

@brittainhard Could you please review?

cc @MattHJensen 