### PR TITLE
Modify row labels for fiscal table

### DIFF
--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -6,6 +6,11 @@ $(function() {
 
         defaults: {
             row_labels: [
+                'Individual Income Tax Liability',
+                'Payroll Tax Liability',
+                'Combined Payroll and Individual Income Tax Liability'
+            ],
+            row_labels_change: [
                 'Individual Income Tax Liability Change',
                 'Payroll Tax Liability Change',
                 'Combined Payroll and Individual Income Tax Liability Change'
@@ -204,7 +209,7 @@ $(function() {
                   <li data-tablename="fiscal_reform" <% if (selectedTableName == "fiscal_reform") { %>class="active" <% } %>><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.fiscal_reform %>" href="#">Reform</a></li>\
                   <li data-tablename="fiscal_change" <% if (selectedTableName == "fiscal_change") { %>class="active" <% } %>><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.fiscal_change %>" href="#">Change</a></li>\
                 </ul>\
-                    <table class="table table-striped" style="width:100%">\
+                    <table class="table table-striped" style="width:95%">\
                         <thead>\
                             <tr>\
                                 <th class="text-center" colspan="<%= model.get("cols").length + 1 %>"><h1><%= model.get("label").toUpperCase() %></h1></th>\
@@ -225,7 +230,7 @@ $(function() {
                             </tr>\
                             <% _.each(model.get("rows"), function(row, idx) { %>\
                             <tr>\
-                                <td class="text-center single-line"><strong><%= model.get("row_labels")[idx] %></strong></td>\
+                                <td class="text-center single-line"><strong><% if (selectedTableName == "fiscal_change") { %><%= model.get("row_labels_change")[idx] %><% } else { %><%= model.get("row_labels")[idx] %><% } %></strong></td>\
                                 <% _.each(row.cells, function(cell, idx) { %>\
                                 <td class="text-center"><% if (cell["tot_value"]) { %><%= cell["tot_value"] %><% } else { %><%= cell["year_values"][model.get("year")] %><% } %></td>\
                                 <% }) %>\

--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -209,7 +209,7 @@ $(function() {
                   <li data-tablename="fiscal_reform" <% if (selectedTableName == "fiscal_reform") { %>class="active" <% } %>><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.fiscal_reform %>" href="#">Reform</a></li>\
                   <li data-tablename="fiscal_change" <% if (selectedTableName == "fiscal_change") { %>class="active" <% } %>><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.fiscal_change %>" href="#">Change</a></li>\
                 </ul>\
-                    <table class="table table-striped" style="width:95%">\
+                    <table class="table table-striped" style="width:100%">\
                         <thead>\
                             <tr>\
                                 <th class="text-center" colspan="<%= model.get("cols").length + 1 %>"><h1><%= model.get("label").toUpperCase() %></h1></th>\

--- a/staticfiles/js/taxbrain-tablebuilder.js
+++ b/staticfiles/js/taxbrain-tablebuilder.js
@@ -6,6 +6,11 @@ $(function() {
 
         defaults: {
             row_labels: [
+                'Individual Income Tax Liability',
+                'Payroll Tax Liability',
+                'Combined Payroll and Individual Income Tax Liability'
+            ],
+            row_labels_change: [
                 'Individual Income Tax Liability Change',
                 'Payroll Tax Liability Change',
                 'Combined Payroll and Individual Income Tax Liability Change'
@@ -204,7 +209,7 @@ $(function() {
                   <li data-tablename="fiscal_reform" <% if (selectedTableName == "fiscal_reform") { %>class="active" <% } %>><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.fiscal_reform %>" href="#">Reform</a></li>\
                   <li data-tablename="fiscal_change" <% if (selectedTableName == "fiscal_change") { %>class="active" <% } %>><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.fiscal_change %>" href="#">Change</a></li>\
                 </ul>\
-                    <table class="table table-striped" style="width:100%">\
+                    <table class="table table-striped" style="width:95%">\
                         <thead>\
                             <tr>\
                                 <th class="text-center" colspan="<%= model.get("cols").length + 1 %>"><h1><%= model.get("label").toUpperCase() %></h1></th>\
@@ -225,7 +230,7 @@ $(function() {
                             </tr>\
                             <% _.each(model.get("rows"), function(row, idx) { %>\
                             <tr>\
-                                <td class="text-center single-line"><strong><%= model.get("row_labels")[idx] %></strong></td>\
+                                <td class="text-center single-line"><strong><% if (selectedTableName == "fiscal_change") { %><%= model.get("row_labels_change")[idx] %><% } else { %><%= model.get("row_labels")[idx] %><% } %></strong></td>\
                                 <% _.each(row.cells, function(cell, idx) { %>\
                                 <td class="text-center"><% if (cell["tot_value"]) { %><%= cell["tot_value"] %><% } else { %><%= cell["year_values"][model.get("year")] %><% } %></td>\
                                 <% }) %>\

--- a/staticfiles/js/taxbrain-tablebuilder.js
+++ b/staticfiles/js/taxbrain-tablebuilder.js
@@ -209,7 +209,7 @@ $(function() {
                   <li data-tablename="fiscal_reform" <% if (selectedTableName == "fiscal_reform") { %>class="active" <% } %>><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.fiscal_reform %>" href="#">Reform</a></li>\
                   <li data-tablename="fiscal_change" <% if (selectedTableName == "fiscal_change") { %>class="active" <% } %>><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.fiscal_change %>" href="#">Change</a></li>\
                 </ul>\
-                    <table class="table table-striped" style="width:95%">\
+                    <table class="table table-striped" style="width:100%">\
                         <thead>\
                             <tr>\
                                 <th class="text-center" colspan="<%= model.get("cols").length + 1 %>"><h1><%= model.get("label").toUpperCase() %></h1></th>\


### PR DESCRIPTION
Per requests in #545, the fiscal year table (a.k.a Total Liabilities table) doesn't have appropriate labels for three cases. More explicitly, when clicking on either Current Law or Reform, then row label indicates "xxxxx Liability Change", which is not appropriate under those two cases. 

This PR drops word "Change" from row labels in those cases. And three tables (reform, current law, and change) will look like the following:

![screen shot 2017-08-15 at 7 35 39 pm](https://user-images.githubusercontent.com/13324931/29342763-a34c9092-81fa-11e7-8e0c-36a2a0051249.png)

![screen shot 2017-08-15 at 7 35 33 pm](https://user-images.githubusercontent.com/13324931/29342764-a3656e32-81fa-11e7-982f-46ccde1e478b.png)

![screen shot 2017-08-15 at 7 35 26 pm](https://user-images.githubusercontent.com/13324931/29342765-a38b5408-81fa-11e7-8aa8-5744af978b77.png)

@brittainhard Could you review?

cc @martinholmer @MattHJensen 
