### PR TITLE
Rename "Diagnostic Table" to "Distribution Table"

### DIFF
--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -306,7 +306,7 @@ $(function() {
                 <br>\
                 <br>\
                 <ul class="nav nav-pills nav-justified">\
-                  <li data-difference="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.diagnostic %>" href="#">Diagnostic Table</a></li>\
+                  <li data-difference="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.distribution %>" href="#">Distribution Table</a></li>\
                   <li data-difference="true" class="active"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.difference %>" href="#">Difference Table</a></li>\
                 </ul>\
                 <br>\

--- a/static/js/vendor/DataTables/datatables.js
+++ b/static/js/vendor/DataTables/datatables.js
@@ -27728,18 +27728,18 @@ DataTable.ext.buttons.csvHtml5 = {
             }
             else if (titles[0] == 'BASE'){
                 if (titles[9] == 'DECILE'){
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_currentlaw_deciles';
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_currentlaw_deciles';
                 }
                 else {
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_currentlaw_bins'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_currentlaw_bins'; 
                 }
             }
             else if (titles[0] == 'USER'){
                 if (titles[9] == 'DECILE'){
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_reform_deciles'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_reform_deciles'; 
                 }
                 else {
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_reform_bins'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_reform_bins'; 
                 }
             }
             else if (titles[0] == 'PAYROLL'){
@@ -27842,18 +27842,18 @@ DataTable.ext.buttons.excelHtml5 = {
             }
             else if (titles[0] == 'BASE'){
                 if (titles[9] == 'DECILE'){
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_currentlaw_deciles'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_currentlaw_deciles'; 
                 }
                 else {
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_currentlaw_bins'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_currentlaw_bins'; 
                 }
             }
             else if (titles[0] == 'USER'){
                 if (titles[9] == 'DECILE'){
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_reform_deciles'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_reform_deciles'; 
                 }
                 else {
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_reform_bins'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_reform_bins'; 
                 }
             }
             else if (titles[0] == 'PAYROLL'){

--- a/staticfiles/js/taxbrain-tablebuilder.js
+++ b/staticfiles/js/taxbrain-tablebuilder.js
@@ -306,7 +306,7 @@ $(function() {
                 <br>\
                 <br>\
                 <ul class="nav nav-pills nav-justified">\
-                  <li data-difference="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.diagnostic %>" href="#">Diagnostic Table</a></li>\
+                  <li data-difference="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.distribution %>" href="#">Distribution Table</a></li>\
                   <li data-difference="true" class="active"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.difference %>" href="#">Difference Table</a></li>\
                 </ul>\
                 <br>\

--- a/staticfiles/js/vendor/DataTables/datatables.js
+++ b/staticfiles/js/vendor/DataTables/datatables.js
@@ -27728,18 +27728,18 @@ DataTable.ext.buttons.csvHtml5 = {
             }
             else if (titles[0] == 'BASE'){
                 if (titles[9] == 'DECILE'){
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_currentlaw_deciles';
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_currentlaw_deciles';
                 }
                 else {
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_currentlaw_bins'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_currentlaw_bins'; 
                 }
             }
             else if (titles[0] == 'USER'){
                 if (titles[9] == 'DECILE'){
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_reform_deciles'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_reform_deciles'; 
                 }
                 else {
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_reform_bins'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_reform_bins'; 
                 }
             }
             else if (titles[0] == 'PAYROLL'){
@@ -27842,18 +27842,18 @@ DataTable.ext.buttons.excelHtml5 = {
             }
             else if (titles[0] == 'BASE'){
                 if (titles[9] == 'DECILE'){
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_currentlaw_deciles'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_currentlaw_deciles'; 
                 }
                 else {
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_currentlaw_bins'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_currentlaw_bins'; 
                 }
             }
             else if (titles[0] == 'USER'){
                 if (titles[9] == 'DECILE'){
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_reform_deciles'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_reform_deciles'; 
                 }
                 else {
-                    var title = '_' + regExp.exec(titles[10])[1] + '_diagnostic_reform_bins'; 
+                    var title = '_' + regExp.exec(titles[10])[1] + '_distribution_reform_bins'; 
                 }
             }
             else if (titles[0] == 'PAYROLL'){

--- a/webapp/apps/constants.py
+++ b/webapp/apps/constants.py
@@ -1,6 +1,6 @@
 import os
 
-DIAGNOSTIC_TOOLTIP = "Key variables in the computation of tax liabilities."
+DISTRIBUTION_TOOLTIP = "Key variables in the computation of tax liabilities."
 DIFFERENCE_TOOLTIP = "Key variables that highlight the differences between two tax plans."
 PAYROLL_TOOLTIP = " Include employee and employer payroll taxes in output."
 INCOME_TOOLTIP = "Include individual income taxes in output."

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -50,7 +50,7 @@ from .compute import DynamicCompute
 
 dynamic_compute = DynamicCompute()
 
-from ..constants import (DIAGNOSTIC_TOOLTIP, DIFFERENCE_TOOLTIP,
+from ..constants import (DISTRIBUTION_TOOLTIP, DIFFERENCE_TOOLTIP,
                           PAYROLL_TOOLTIP, INCOME_TOOLTIP, BASE_TOOLTIP,
                           REFORM_TOOLTIP, EXPANDED_TOOLTIP,
                           ADJUSTED_TOOLTIP, INCOME_BINS_TOOLTIP,
@@ -750,7 +750,7 @@ def behavior_results(request, pk):
 
         tables = taxcalc_results_to_tables(output, first_year)
         tables["tooltips"] = {
-            'diagnostic': DIAGNOSTIC_TOOLTIP,
+            'distribution': DISTRIBUTION_TOOLTIP,
             'difference': DIFFERENCE_TOOLTIP,
             'payroll': PAYROLL_TOOLTIP,
             'income': INCOME_TOOLTIP,

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -44,7 +44,7 @@ from .compute import DropqCompute, MockCompute, JobFailError
 
 dropq_compute = DropqCompute()
 
-from ..constants import (DIAGNOSTIC_TOOLTIP, DIFFERENCE_TOOLTIP,
+from ..constants import (DISTRIBUTION_TOOLTIP, DIFFERENCE_TOOLTIP,
                          PAYROLL_TOOLTIP, INCOME_TOOLTIP, BASE_TOOLTIP,
                          REFORM_TOOLTIP, EXPANDED_TOOLTIP, ADJUSTED_TOOLTIP,
                          FISCAL_CURRENT_LAW, FISCAL_REFORM, FISCAL_CHANGE,
@@ -500,7 +500,7 @@ def get_result_context(model, request, url):
 
     tables = taxcalc_results_to_tables(output, first_year)
     tables["tooltips"] = {
-        'diagnostic': DIAGNOSTIC_TOOLTIP,
+        'distribution': DISTRIBUTION_TOOLTIP,
         'difference': DIFFERENCE_TOOLTIP,
         'payroll': PAYROLL_TOOLTIP,
         'income': INCOME_TOOLTIP,


### PR DESCRIPTION
Per request in #620, one of the buttons in "build table" option is mislabeled. This PR renames "diagnostic" as "distribution" for this particular button, as well as for the tooltips in the code base. 

After this PR, the build table panel would look like the following:

<img width="557" alt="screen shot 2017-08-17 at 3 43 11 pm" src="https://user-images.githubusercontent.com/13324931/29430778-c3a850dc-8363-11e7-8310-efe080de5d64.png">
 
@brittainhard could you please review?

cc @martinholmer @MattHJensen 