### PR TITLE
Add summary row for table

### DIFF
--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -481,6 +481,25 @@ def edit_personal_results(request, pk):
     return render(request, 'taxbrain/input_form.html', init_context)
 
 
+def add_summary_column(table):
+    import copy
+    summary = copy.deepcopy(table["cols"][-1])
+    summary["label"] = "Summary"
+    table["cols"].append(summary)
+    table["col_labels"].append("Summary")
+    for x in table["rows"]:
+        row_total = 0
+        for y in x["cells"]:
+            row_total += float(y["value"])
+        x["cells"].append({
+            'format': {u'decimals': 1, u'divisor': 1000000000},
+            u'value': unicode(row_total),
+            u'year_values': {}
+        })
+    return table
+
+
+
 def get_result_context(model, request, url):
     output = model.tax_result
     first_year = model.first_year
@@ -528,9 +547,9 @@ def get_result_context(model, request, url):
         is_registered = True if request.user.is_authenticated() else False
     else:
         is_registered = False
-    tables['fiscal_change'] = tables['fiscal_tot_diffs']
-    tables['fiscal_currentlaw'] = tables['fiscal_tot_base']
-    tables['fiscal_reform'] = tables['fiscal_tot_ref']
+    tables['fiscal_change'] = add_summary_column(tables['fiscal_tot_diffs'])
+    tables['fiscal_currentlaw'] = add_summary_column(tables['fiscal_tot_base'])
+    tables['fiscal_reform'] = add_summary_column(tables['fiscal_tot_ref'])
     json_table = json.dumps(tables)
 
     context = {

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -484,15 +484,18 @@ def edit_personal_results(request, pk):
 def add_summary_column(table):
     import copy
     summary = copy.deepcopy(table["cols"][-1])
-    summary["label"] = "Summary"
+    summary["label"] = "Total"
     table["cols"].append(summary)
-    table["col_labels"].append("Summary")
+    table["col_labels"].append("Total")
     for x in table["rows"]:
         row_total = 0
         for y in x["cells"]:
             row_total += float(y["value"])
         x["cells"].append({
-            'format': {u'decimals': 1, u'divisor': 1000000000},
+            'format': {
+                u'decimals': 1,
+                u'divisor': 1000000000
+            },
             u'value': unicode(row_total),
             u'year_values': {}
         })


### PR DESCRIPTION
@GoFroggyRun this is a dirty prototype but it works. It just loops through the tables of the existing data structure and adds up their values, then creates a new column. The front-end is handling it well, no changes need to be made there. I haven't tested this solution thoroughly, and the code could be improved. This is a good basis for the feature I think. My output from a reform looks like this:

<img width="1380" alt="screen shot 2017-09-01 at 1 44 29 pm" src="https://user-images.githubusercontent.com/5440553/29983577-35948904-8f1c-11e7-8438-6b81eeb3a1fc.png">

It's adding the column AFTER the table has already been saved in the database. I think this can also be done after before the data is saved in the database. I don't think that will cause issues with backwards compatibility since the javascript table is just accepting arbitrary data as long as its in the right format.

@martinholmer @hdoupe your input on this would he helpful I think.