### PR TITLE
Fix Payroll Tax + Income Tax buttons on difference table

### DIFF
--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -318,7 +318,7 @@ $(function() {
                 <ul id="tax" class="nav nav-pills nav-justified">\
                   <li class="active" data-payrolltax="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.payroll %>" href="#">Payroll Tax</a></li>\
                   <li><h1 class="text-center" style="margin:0">+</h1></li>\
-                  <li class="active" data-incometax="true"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.income %>" href="#">Income Tax</a></li>\
+                  <li class="active" data-incometax="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.income %>" href="#">Income Tax</a></li>\
                 </ul>\
                 <br>\
                 <br>\

--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -316,9 +316,9 @@ $(function() {
                   <li data-plan="Y"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.reform %>" href="#">Reform</a></li>\
                 </ul>\
                 <ul id="tax" class="nav nav-pills nav-justified">\
-                  <li class="active" data-payrolltax="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.payroll %>" href="#">Payroll</a></li>\
+                  <li class="active" data-payrolltax="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.payroll %>" href="#">Payroll Tax</a></li>\
                   <li><h1 class="text-center" style="margin:0">+</h1></li>\
-                  <li class="active" data-incometax="true"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.income %>" href="#">Income</a></li>\
+                  <li class="active" data-incometax="true"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.income %>" href="#">Income Tax</a></li>\
                 </ul>\
                 <br>\
                 <br>\

--- a/staticfiles/js/taxbrain-tablebuilder.js
+++ b/staticfiles/js/taxbrain-tablebuilder.js
@@ -316,9 +316,9 @@ $(function() {
                   <li data-plan="Y"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.reform %>" href="#">Reform</a></li>\
                 </ul>\
                 <ul id="tax" class="nav nav-pills nav-justified">\
-                  <li class="active" data-payrolltax="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.payroll %>" href="#">Payroll</a></li>\
+                  <li class="active" data-payrolltax="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.payroll %>" href="#">Payroll Tax</a></li>\
                   <li><h1 class="text-center" style="margin:0">+</h1></li>\
-                  <li class="active" data-incometax="true"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.income %>" href="#">Income</a></li>\
+                  <li class="active" data-incometax="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.income %>" href="#">Income Tax</a></li>\
                 </ul>\
                 <br>\
                 <br>\


### PR DESCRIPTION
This PR fixes the bug reported in #644. 

Before this PR, when payroll tax is ON and income tax is OFF, the difference table will show combined taxes; when payroll tax is ON and income tax is ON, the difference table will show payroll taxes. Both cases are incorrect. 

The fix in this PR assigns proper data to each button so that:
```
Pay_taxes is ON    Inc_taxes is ON    ===>  Combined taxes are shown
Pay_taxes is ON    Inc_taxes is OFF   ===>  Payroll taxes are shown
Pay_taxes is OFF   Inc_taxes is ON    ===>  Income taxes are shown
Pay_taxes is OFF   Inc_taxes is OFF   ===>  Nothing is shown
```

This PR also changes the two buttons' names from "Payroll" and "Income" to "Payroll Tax" and "Income Tax", as requested in #644 .

However, turning OFF the two buttons, namely "Payroll Tax" and "Income Tax", are still allowed. I have not come up with a fix for this. 

@brittainhard Could you review? 

cc @martinholmer @MattHJensen 