### PR TITLE
Remove submit_micro function

### DIFF
--- a/webapp/apps/taxbrain/urls.py
+++ b/webapp/apps/taxbrain/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, include, url
 
 from .views import (personal_results, output_detail, csv_input, csv_output,
-                    pdf_view, edit_personal_results, submit_micro, file_input)
+                    pdf_view, edit_personal_results, file_input)
 
 
 
@@ -11,7 +11,6 @@ urlpatterns = patterns('',
     url(r'^(?P<pk>\d+)/output.csv/$', csv_output, name='csv_output'),
     url(r'^(?P<pk>\d+)/input.csv/$', csv_input, name='csv_input'),
     url(r'^(?P<pk>\d+)/', output_detail, name='output_detail'),
-    url(r'^submit/(?P<pk>\d+)/', submit_micro, name='submit_micro'),
     url(r'^pdf/$', pdf_view),
     url(r'^edit/(?P<pk>\d+)/', edit_personal_results, name='edit_personal_results'),
 )

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -563,34 +563,6 @@ def personal_results(request):
     return render(request, 'taxbrain/input_form.html', init_context)
 
 
-def submit_micro(request, pk):
-    """
-    This view handles the re-submission of a previously submitted microsim.
-    Its primary purpose is to facilitate a mechanism to submit a full microsim
-    job after one has submitted parameters for a 'quick calculation'
-    """
-    #TODO: get this function to work with submit_reform
-    try:
-        url = OutputUrl.objects.get(pk=pk)
-    except:
-        raise Http404
-
-    model = TaxSaveInputs.objects.get(pk=url.model_pk)
-    # This will be a new model instance so unset the primary key
-    model.pk = None
-    # Unset the computed results, set quick_calc to False
-    # (this new model instance will be saved in process_model)
-    model.job_ids = None
-    model.jobs_not_ready = None
-    model.quick_calc = False
-    model.tax_result = None
-
-    log_ip(request)
-    unique_url = process_model(model, start_year=str(model.first_year),
-                               do_full_calc=True, user=url.user)
-    return redirect(unique_url)
-
-
 def edit_personal_results(request, pk):
     """
     This view handles the editing of previously entered inputs


### PR DESCRIPTION
This PR removes the `taxbrain/views.submit_micro` function.  It appears that this function would be called to submit a reform after the user submitted the reform using the quick-calc option.  However, the `edit_personal_results function` is now used for this.