### PR TITLE
Adding dynamic CDNs for the widgets

### DIFF
--- a/templates/btax/results.html
+++ b/templates/btax/results.html
@@ -10,9 +10,9 @@
 <link rel='stylesheet' href={{cdn_css|safe}} type="text/css"/>
 <script type="text/javascript" src={{cdn_js|safe}}></script>
 <link
-  href="https://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.7.min.css"
+  href={{widget_css|safe}}
   rel="stylesheet" type="text/css">
-<script src="https://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.7.min.js"></script>
+<script type="text/javascript" src={{widget_js|safe}}></script>
 
 <style>
   .btn {

--- a/webapp/apps/btax/bubble_plot/bubble_plot_tabs.py
+++ b/webapp/apps/btax/bubble_plot/bubble_plot_tabs.py
@@ -237,5 +237,7 @@ def bubble_plot_tabs(dataframes):
     js, div = components(layout)
     cdn_js = CDN.js_files[0]
     cdn_css = CDN.css_files[0]
+    widget_js = CDN.js_files[1]
+    widget_css = CDN.css_files[1]
 
-    return js, div, cdn_js, cdn_css
+    return js, div, cdn_js, cdn_css, widget_js, widget_css

--- a/webapp/apps/btax/views.py
+++ b/webapp/apps/btax/views.py
@@ -366,7 +366,7 @@ def output_detail(request, pk):
             "coc": COC_TOOLTIP,
             "dprc": DPRC_TOOLTIP,
         }
-        bubble_js, bubble_div, cdn_js, cdn_css = bubble_plot_tabs(model.tax_result[0]['dataframes'])
+        bubble_js, bubble_div, cdn_js, cdn_css, widget_js, widget_css = bubble_plot_tabs(model.tax_result[0]['dataframes'])
 
         inputs = url.unique_inputs
         is_registered = True if request.user.is_authenticated() else False
@@ -382,6 +382,8 @@ def output_detail(request, pk):
             'bubble_div': bubble_div,
             'cdn_js': cdn_js,
             'cdn_css': cdn_css,
+            'widget_js': widget_js,
+            'widget_css': widget_css
         })
         context.update(context_vers_disp)
         return render(request, 'btax/results.html', context)


### PR DESCRIPTION
Bokeh visualization working on 0.12.9 and CDNs for widgets now dynamic, rather than being pinned to a specific version.

Issue #687 