### PR TITLE
Pin Bokeh to 0.12.7

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -6,4 +6,4 @@ pandas
 gevent
 pillow
 pyparsing
-bokeh>=0.12.7
+bokeh=0.12.7


### PR DESCRIPTION
This PR pins Bokeh to version 0.12.7.  See PR #687 and issue #686 for further discussion.