### PR TITLE
Enhance file upload preview

### DIFF
--- a/templates/taxbrain/results.html
+++ b/templates/taxbrain/results.html
@@ -71,7 +71,7 @@
         {% endif %}
       </div>
       {% if reform_file_contents %}
-      <h2> The following reform file were uploaded for this simulation: </h2>
+      <h2> The following reform file(s) were uploaded for this simulation: </h2>
       <div class="file-contents">
           {%autoescape off %}
           {{ raw_reform_text  | nbsp | safe | linebreaks}}

--- a/templates/taxbrain/results.html
+++ b/templates/taxbrain/results.html
@@ -2,6 +2,7 @@
 {% load staticfiles %}
 {% load flatblocks %}
 {% block style %}
+{% load results %}
 {{block.super}}
 <link href="{% static 'css/vendor/bootstrap3-block-grid.min.css' %}" rel="stylesheet">
 <link href="text/javascript" src="{% static 'js/vendor/DataTables/datatables.min.css' %}"></link>
@@ -70,10 +71,10 @@
         {% endif %}
       </div>
       {% if reform_file_contents %}
-      <h2> The following reform files were uploaded for this simulation: </h2>
+      <h2> The following reform file were uploaded for this simulation: </h2>
       <div class="file-contents">
           {%autoescape off %}
-          {{ raw_reform_text | linebreaks | safe }}
+          {{ raw_reform_text  | nbsp | safe | linebreaks}}
           {%endautoescape %}
           {%autoescape off %}
           {{ raw_assumption_text | linebreaks | safe }}

--- a/templates/taxbrain/results.html
+++ b/templates/taxbrain/results.html
@@ -74,10 +74,10 @@
       <h2> The following reform file(s) were uploaded for this simulation: </h2>
       <div class="file-contents">
           {%autoescape off %}
-          {{ raw_reform_text  | nbsp | safe | linebreaks}}
+          {{ raw_reform_text  | nbsp | linebreaks | safe}}
           {%endautoescape %}
           {%autoescape off %}
-          {{ raw_assumption_text | linebreaks | safe }}
+          {{ raw_assumption_text | nbsp | linebreaks | safe}}
           {%endautoescape %}
        </div>
       {% endif %}

--- a/webapp/apps/taxbrain/templatetags/results.py
+++ b/webapp/apps/taxbrain/templatetags/results.py
@@ -2,6 +2,7 @@ from django import template
 import math
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.template.defaultfilters import floatformat
+from django.utils.safestring import mark_safe
 
 SCALES = [
     None,
@@ -56,3 +57,7 @@ def floatformat_all(values, decimals):
     for value in values:
         new_values[value] = floatformat(values[value], decimals)
     return new_values
+
+@register.filter()
+def nbsp(value):
+    return mark_safe("&nbsp;".join(value.split(' ')))


### PR DESCRIPTION
This PR closes #500. A filter, `nbsp`, is added to disable stripping white spaces. Also modified title name as suggested in #500 by @MattHJensen.

Before this PR, the file upload section looks like: 

![screen shot 2017-10-12 at 2 16 09 pm](https://user-images.githubusercontent.com/13324931/31512177-029d45ca-af58-11e7-8640-3e5712ace0fc.png)


The new file preview looks like:

![screen shot 2017-10-12 at 2 00 36 pm](https://user-images.githubusercontent.com/13324931/31511544-1024d6f6-af56-11e7-9220-421b89821d3b.png)

where the uploaded file looks like:
```
{
    "policy": {
        "_SS_Earnings_c": {"2018": [400000], "2019": [500000], "2020": [600000], "2021": [600000], "2022": [600000], "2023": [600000], "2024": [600000]},
        "_II_em": {"2018": [8000]},
        "_II_em_cpi": {"2018": false,
                       "2020": true},
        "_ALD_InvInc_ec_rt": {"2019": [0.20]}
    }
}
```