### PR TITLE
Unit test parameter formatters 

### DIFF
--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -280,7 +280,11 @@ def get_default_policy_param_name(param, default_params):
             ix = int(end_piece)
         except ValueError:
             msg = "Parsing {}: Expected integer for index but got {}"
-            raise ValueError(msg.format(param, ix))
+            raise ValueError(msg.format(param, end_piece))
+        num_columns = len(default_params[no_suffix]['col_label'])
+        if ix < 0 or ix >= num_columns:
+            msg = "Parsing {}: Index {} not in range ({}, {})"
+            raise IndexError(msg.format(param, ix, 0, num_columns))
         col_label = default_params[no_suffix]['col_label'][ix]
         return no_suffix + '_' + col_label
     msg = "Received unexpected parameter: {}"

--- a/webapp/apps/test_assets/test_assumptions.py
+++ b/webapp/apps/test_assets/test_assumptions.py
@@ -8,3 +8,11 @@ assumptions_text = """{
     "consumption": {},
     "growdiff_baseline": {}
 }"""
+
+exp_assumptions_text = {
+    'growdiff_response': {},
+    'consumption': {},
+    'behavior': {
+        2017: {u'_BE_sub': [1.0], u'_BE_inc': [-0.6], u'_BE_cg': [-0.67]}},
+    'growdiff_baseline': {}
+}

--- a/webapp/apps/test_assets/test_assumptions.py
+++ b/webapp/apps/test_assets/test_assumptions.py
@@ -16,3 +16,12 @@ exp_assumptions_text = {
         2017: {u'_BE_sub': [1.0], u'_BE_inc': [-0.6], u'_BE_cg': [-0.67]}},
     'growdiff_baseline': {}
 }
+
+no_assumptions_text = """
+{
+    "growdiff_response": {},
+    "consumption": {},
+    "behavior": {},
+    "growdiff_baseline": {}
+}
+"""

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -27,6 +27,10 @@ def default_params_Policy():
 
 ###############################################################################
 # Test get_default_policy_param_name
+# 3 Cases for search success:
+#   1. "_" + param name
+#   2. "_" + param name + index name (i.e. STD_0 --> _STD_single)
+#   3. "_" + param name minus "_cpi"
 @pytest.mark.parametrize("param,exp_param",
                          [("FICA_ss_trt", "_FICA_ss_trt"),
                           ("ID_BenefitSurtax_Switch_0", "_ID_BenefitSurtax_Switch_medical"),
@@ -37,12 +41,19 @@ def test_get_default_policy_param_name_passing(param, exp_param, default_params_
 
 @pytest.mark.parametrize("param", ["CG_brk3_extra_cpi", "not_a_param"])
 def test_get_default_policy_param_name_failing0(param, default_params_Policy):
+    """
+    Check that non-recognized parameters throw a ValueError
+    """
     match="Received unexpected parameter: {0}".format(param)
     with pytest.raises(ValueError, match=match):
         get_default_policy_param_name(param, default_params_Policy)
 
 
 def test_get_default_policy_param_name_failing1(default_params_Policy):
+    """
+    Check that parameter with non-integer characters after the final '_'
+    throws ValueError
+    """
     param = "ID_BenefitSurtax_Switch_idx"
     match = "Parsing {}: Expected integer for index but got {}".format(param, "idx")
     with pytest.raises(ValueError, match=match):
@@ -50,6 +61,10 @@ def test_get_default_policy_param_name_failing1(default_params_Policy):
 
 
 def test_get_default_policy_param_name_failing2(default_params_Policy):
+    """
+    Check that parameter with correct name but out of bounds index throws
+    IndexError
+    """
     param = "ID_BenefitSurtax_Switch_12"
     # comment out "(" since this is treated as a regexp string
     match = "Parsing {}: Index {} not in range \({}, {}\)"
@@ -59,6 +74,9 @@ def test_get_default_policy_param_name_failing2(default_params_Policy):
 
 ###############################################################################
 # Test to_json_reform
+# 2 Cases:
+#   1. Fields do not cause errors
+#   2. Fields cause errors
 @pytest.mark.parametrize(
     ("fields,exp_reform"),
     [(test_coverage_fields, test_coverage_reform),
@@ -77,6 +95,10 @@ def test_parse_errors_warnings():
 
 ###############################################################################
 # Test read_json_reform
+# 3 Cases:
+#   1. Reform does not throw errors and no behavior assumptions are made
+#   2. Reform does not throw errors and behavior assumptions are made
+#   3. Reform throws errors and warnings and behavior assumptions are not made
 @pytest.mark.parametrize(
     ("test_reform,test_assump,map_back_to_tb,exp_reform,exp_assump,"
      "exp_errors_warnings"),

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -9,11 +9,14 @@ from ..taxbrain.helpers import (get_default_policy_param_name, to_json_reform)
 
 from test_reform import (test_coverage_fields, test_coverage_reform,
                          test_coverage_json_reform,
-                         test_coverage_json_assumptions,
-                         map_back_to_tb,
-                         test_coverage_exp_read_json_reform)
+                         test_coverage_exp_read_json_reform,
+                         errors_warnings_fields, errors_warnings_reform,
+                         errors_warnings_json_reform,
+                         errors_warnings_exp_read_json_reform,
+                         errors_warnings, exp_errors_warnings,
+                         map_back_to_tb)
 
-from test_assumptions import assumptions_text, exp_assumptions_text
+from test_assumptions import (assumptions_text, exp_assumptions_text, no_assumptions_text)
 
 START_YEAR = 2017
 
@@ -55,104 +58,40 @@ def test_get_default_policy_param_name_failing2(default_params_Policy):
 
 ###############################################################################
 # Test to_json_reform
-
-def test_to_json_reform():
-    act, _ = to_json_reform(test_coverage_fields, START_YEAR)
-    np.testing.assert_equal(act, test_coverage_reform)
+@pytest.mark.parametrize(
+    ("fields,exp_reform"),
+    [(test_coverage_fields, test_coverage_reform),
+     (errors_warnings_fields, errors_warnings_reform)]
+)
+def test_to_json_reform(fields, exp_reform):
+    act, _ = to_json_reform(fields, START_YEAR)
+    print(exp_reform)
+    print(act)
+    np.testing.assert_equal(act, exp_reform)
 
 ###############################################################################
 # Test parse_errors_warnings
-REFORM_WARNINGS_ERRORS = {
-    u'policy': {
-        u'_STD_single': {u'2017': [7000.0]},
-        u'_FICA_ss_trt': {u'2017': [-1.0], u'2019': [0.1]},
-        u'_II_brk4_single': {u'2017': [500.0]},
-        u'_STD_headhousehold': {u'2017': [10000.0], u'2020': [150.0]},
-        u'_ID_BenefitSurtax_Switch_medical': {u'2017': [True]}
-    }
-}
-
-ERRORS = ("ERROR: 2017 _FICA_ss_trt value -1.0 < min value 0\n"
-          "ERROR: 2018 _FICA_ss_trt value -1.0 < min value 0\n"
-          "ERROR: 2017 _II_brk4_0 value 500.0 < min value 91900.0 for _II_brk3_0\n"
-          "ERROR: 2018 _II_brk4_0 value 511.1 < min value 93940.18 for _II_brk3_0\n"
-          "ERROR: 2019 _II_brk4_0 value 522.8 < min value 96091.41 for _II_brk3_0\n"
-          "ERROR: 2020 _II_brk4_0 value 534.98 < min value 98330.34 for _II_brk3_0\n"
-          "ERROR: 2021 _II_brk4_0 value 547.45 < min value 100621.44 for _II_brk3_0\n"
-          "ERROR: 2022 _II_brk4_0 value 560.15 < min value 102955.86 for _II_brk3_0\n"
-          "ERROR: 2023 _II_brk4_0 value 573.2 < min value 105354.73 for _II_brk3_0\n"
-          "ERROR: 2024 _II_brk4_0 value 586.56 < min value 107809.5 for _II_brk3_0\n"
-          "ERROR: 2025 _II_brk4_0 value 600.29 < min value 110332.24 for _II_brk3_0\n"
-          "ERROR: 2026 _II_brk4_0 value 614.4 < min value 112925.05 for _II_brk3_0\n")
-
-WARNINGS = ("WARNING: 2020 _STD_3 value 150.0 < min value 10004.23\n"
-            "WARNING: 2021 _STD_3 value 153.5 < min value 10237.33\n"
-            "WARNING: 2022 _STD_3 value 157.06 < min value 10474.84\n"
-            "WARNING: 2023 _STD_3 value 160.72 < min value 10718.9\n"
-            "WARNING: 2024 _STD_3 value 164.46 < min value 10968.65\n"
-            "WARNING: 2025 _STD_3 value 168.31 < min value 11225.32\n"
-            "WARNING: 2026 _STD_3 value 172.27 < min value 11489.12\n")
-
-ERRORS_WARNINGS = {'errors': ERRORS, 'warnings': WARNINGS}
-
-EXP_ERRORS_WARNINGS = {
-    'errors': {
-        '2024': {'II_brk4_0': 'ERROR: value 586.56 < min value 107809.5 for _II_brk3_0 for 2024'},
-        '2025': {'II_brk4_0': 'ERROR: value 600.29 < min value 110332.24 for _II_brk3_0 for 2025'},
-        '2026': {'II_brk4_0': 'ERROR: value 614.4 < min value 112925.05 for _II_brk3_0 for 2026'},
-        '2020': {'II_brk4_0': 'ERROR: value 534.98 < min value 98330.34 for _II_brk3_0 for 2020'},
-        '2018': {'FICA_ss_trt': 'ERROR: value -1.0 < min value 0 for 2018',
-                 'II_brk4_0': 'ERROR: value 511.1 < min value 93940.18 for _II_brk3_0 for 2018'},
-        '2022': {'II_brk4_0': 'ERROR: value 560.15 < min value 102955.86 for _II_brk3_0 for 2022'},
-        '2023': {'II_brk4_0': 'ERROR: value 573.2 < min value 105354.73 for _II_brk3_0 for 2023'},
-        '2019': {'II_brk4_0': 'ERROR: value 522.8 < min value 96091.41 for _II_brk3_0 for 2019'},
-        '2017': {'FICA_ss_trt': 'ERROR: value -1.0 < min value 0 for 2017',
-                 'II_brk4_0': 'ERROR: value 500.0 < min value 91900.0 for _II_brk3_0 for 2017'},
-        '2021': {'II_brk4_0': 'ERROR: value 547.45 < min value 100621.44 for _II_brk3_0 for 2021'}
-        },
-    'warnings': {
-        '2024': {'STD_3': 'WARNING: value 164.46 < min value 10968.65 for 2024'},
-        '2025': {'STD_3': 'WARNING: value 168.31 < min value 11225.32 for 2025'},
-        '2026': {'STD_3': 'WARNING: value 172.27 < min value 11489.12 for 2026'},
-        '2020': {'STD_3': 'WARNING: value 150.0 < min value 10004.23 for 2020'},
-        '2021': {'STD_3': 'WARNING: value 153.5 < min value 10237.33 for 2021'},
-        '2022': {'STD_3': 'WARNING: value 157.06 < min value 10474.84 for 2022'},
-        '2023': {'STD_3': 'WARNING: value 160.72 < min value 10718.9 for 2023'}
-    }
-}
-
-
 def test_parse_errors_warnings():
-    act = parse_errors_warnings(ERRORS_WARNINGS, map_back_to_tb)
-    np.testing.assert_equal(EXP_ERRORS_WARNINGS, act)
+    act = parse_errors_warnings(errors_warnings, map_back_to_tb)
+    np.testing.assert_equal(exp_errors_warnings, act)
 
 
 ###############################################################################
 # Test read_json_reform
-
-exp_reform_errors_warnings = {
-    2017:
-        {u'_II_brk4': [[500.0, 233350.0, 116675.0, 212500.0, 233350.0]],
-        u'_STD': [[7000.0, 12700.0, 6350.0, 10000.0, 12700.0]],
-        u'_ID_BenefitSurtax_Switch': [[True, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]],
-        u'_FICA_ss_trt': [-1.0]},
-    2019: {u'_FICA_ss_trt': [0.1]},
-    2020: {u'_STD': [[7489.8, 13588.64, 6794.31, 150.0, 13588.64]]}
-}
-
 @pytest.mark.parametrize(
     ("test_reform,test_assump,map_back_to_tb,exp_reform,exp_assump,"
      "exp_errors_warnings"),
-    [(test_coverage_json_reform, test_coverage_json_assumptions,
+    [(test_coverage_json_reform, no_assumptions_text,
       map_back_to_tb, test_coverage_exp_read_json_reform,
-      json.loads(test_coverage_json_assumptions),
+      json.loads(no_assumptions_text),
       {'errors': {}, 'warnings': {}}),
      (test_coverage_json_reform, assumptions_text,
       map_back_to_tb, test_coverage_exp_read_json_reform,
       exp_assumptions_text,
       {'errors': {}, 'warnings': {}}),
-     (json.dumps(REFORM_WARNINGS_ERRORS), test_coverage_json_assumptions, map_back_to_tb,
-      exp_reform_errors_warnings, json.loads(test_coverage_json_assumptions), EXP_ERRORS_WARNINGS)
+     (errors_warnings_json_reform, no_assumptions_text,
+      map_back_to_tb, errors_warnings_exp_read_json_reform,
+      json.loads(no_assumptions_text), exp_errors_warnings)
      ]
 )
 def test_read_json_reform(test_reform, test_assump, map_back_to_tb,

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -34,7 +34,7 @@ def default_params_Policy():
                           ("CG_brk3_cpi", "_CG_brk3_cpi")])
 def test_get_default_policy_param_name_passing(param, exp_param, default_params_Policy):
     act_param = get_default_policy_param_name(param, default_params_Policy)
-    assert act_param == exp_param
+    np.testing.assert_equal(act_param, exp_param)
 
 @pytest.mark.parametrize("param", ["CG_brk3_extra_cpi", "not_a_param"])
 def test_get_default_policy_param_name_failing0(param, default_params_Policy):
@@ -65,8 +65,6 @@ def test_get_default_policy_param_name_failing2(default_params_Policy):
 )
 def test_to_json_reform(fields, exp_reform):
     act, _ = to_json_reform(fields, START_YEAR)
-    print(exp_reform)
-    print(act)
     np.testing.assert_equal(act, exp_reform)
 
 ###############################################################################

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -10,10 +10,10 @@ from ..taxbrain.helpers import (get_default_policy_param_name, to_json_reform)
 from test_reform import (test_coverage_fields, test_coverage_reform,
                          test_coverage_json_reform,
                          test_coverage_json_assumptions,
-                         test_coverage_map_back_to_tb,
+                         map_back_to_tb,
                          test_coverage_exp_read_json_reform)
 
-from test_assumptions import assumptions_text
+from test_assumptions import assumptions_text, exp_assumptions_text
 
 START_YEAR = 2017
 
@@ -121,47 +121,47 @@ EXP_ERRORS_WARNINGS = {
     }
 }
 
-MAP_BACK_TO_TB = {
-    u'_STD_single': 'STD_0',
-    '_FICA_ss_trt': 'FICA_ss_trt',
-    u'_STD_headhousehold': 'STD_3',
-    u'_II_brk4_single': 'II_brk4_0',
-    u'_ID_BenefitSurtax_Switch_medical': 'ID_BenefitSurtax_Switch_0'
-}
 
 def test_parse_errors_warnings():
-    act = parse_errors_warnings(ERRORS_WARNINGS, MAP_BACK_TO_TB)
+    act = parse_errors_warnings(ERRORS_WARNINGS, map_back_to_tb)
     np.testing.assert_equal(EXP_ERRORS_WARNINGS, act)
 
 
 ###############################################################################
 # Test read_json_reform
+
+exp_reform_errors_warnings = {
+    2017:
+        {u'_II_brk4': [[500.0, 233350.0, 116675.0, 212500.0, 233350.0]],
+        u'_STD': [[7000.0, 12700.0, 6350.0, 10000.0, 12700.0]],
+        u'_ID_BenefitSurtax_Switch': [[True, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]],
+        u'_FICA_ss_trt': [-1.0]},
+    2019: {u'_FICA_ss_trt': [0.1]},
+    2020: {u'_STD': [[7489.8, 13588.64, 6794.31, 150.0, 13588.64]]}
+}
+
 @pytest.mark.parametrize(
     ("test_reform,test_assump,map_back_to_tb,exp_reform,exp_assump,"
      "exp_errors_warnings"),
     [(test_coverage_json_reform, test_coverage_json_assumptions,
-      test_coverage_map_back_to_tb, test_coverage_exp_read_json_reform,
+      map_back_to_tb, test_coverage_exp_read_json_reform,
       json.loads(test_coverage_json_assumptions),
       {'errors': {}, 'warnings': {}}),
-      (test_coverage_json_reform, assumptions_text,
-        test_coverage_map_back_to_tb, test_coverage_exp_read_json_reform,
-        json.loads(assumptions_text),
-        {'errors': {}, 'warnings': {}}),
-     (REFORM_WARNINGS_ERRORS, test_coverage_json_assumptions, MAP_BACK_TO_TB,
-      False, json.loads(test_coverage_json_assumptions), ERRORS_WARNINGS)
+     (test_coverage_json_reform, assumptions_text,
+      map_back_to_tb, test_coverage_exp_read_json_reform,
+      exp_assumptions_text,
+      {'errors': {}, 'warnings': {}}),
+     (json.dumps(REFORM_WARNINGS_ERRORS), test_coverage_json_assumptions, map_back_to_tb,
+      exp_reform_errors_warnings, json.loads(test_coverage_json_assumptions), EXP_ERRORS_WARNINGS)
      ]
 )
 def test_read_json_reform(test_reform, test_assump, map_back_to_tb,
                           exp_reform, exp_assump, exp_errors_warnings):
-    exp_assump = json.loads(test_coverage_json_assumptions)
-    exp_errors_warnings = {'errors': {}, 'warnings': {}}
-
     act_reform, act_assump, act_errors_warnings = read_json_reform(
-        test_coverage_json_reform,
-        test_coverage_json_assumptions,
-        test_coverage_map_back_to_tb
+        test_reform,
+        test_assump,
+        map_back_to_tb
     )
-
-    np.testing.assert_equal(test_coverage_exp_read_json_reform, act_reform)
+    np.testing.assert_equal(exp_reform, act_reform)
     np.testing.assert_equal(exp_assump, act_assump)
     np.testing.assert_equal(exp_errors_warnings, act_errors_warnings)

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -1,0 +1,167 @@
+import json
+import pytest
+import taxcalc
+import numpy as np
+
+from ..taxbrain.views import (parse_errors_warnings, read_json_reform,
+                              get_reform_from_gui, get_reform_from_file)
+from ..taxbrain.helpers import (get_default_policy_param_name, to_json_reform)
+
+from test_reform import (test_coverage_fields, test_coverage_reform,
+                         test_coverage_json_reform,
+                         test_coverage_json_assumptions,
+                         test_coverage_map_back_to_tb,
+                         test_coverage_exp_read_json_reform)
+
+from test_assumptions import assumptions_text
+
+START_YEAR = 2017
+
+@pytest.fixture
+def default_params_Policy():
+    return taxcalc.Policy.default_data(start_year=START_YEAR,
+                                       metadata=True)
+
+
+###############################################################################
+# Test get_default_policy_param_name
+@pytest.mark.parametrize("param,exp_param",
+                         [("FICA_ss_trt", "_FICA_ss_trt"),
+                          ("ID_BenefitSurtax_Switch_0", "_ID_BenefitSurtax_Switch_medical"),
+                          ("CG_brk3_cpi", "_CG_brk3_cpi")])
+def test_get_default_policy_param_name_passing(param, exp_param, default_params_Policy):
+    act_param = get_default_policy_param_name(param, default_params_Policy)
+    assert act_param == exp_param
+
+@pytest.mark.parametrize("param", ["CG_brk3_extra_cpi", "not_a_param"])
+def test_get_default_policy_param_name_failing0(param, default_params_Policy):
+    match="Received unexpected parameter: {0}".format(param)
+    with pytest.raises(ValueError, match=match):
+        get_default_policy_param_name(param, default_params_Policy)
+
+
+def test_get_default_policy_param_name_failing1(default_params_Policy):
+    param = "ID_BenefitSurtax_Switch_idx"
+    match="Parsing {0}: Index {0} not in range".format(param, "idx")
+    with pytest.raises(ValueError, match=match):
+        get_default_policy_param_name(param, default_params_Policy)
+
+
+def test_get_default_policy_param_name_failing2(default_params_Policy):
+    param = "ID_BenefitSurtax_Switch_12"
+    match="Parsing {}: Expected integer for index but got {}".format(param, "12")
+    with pytest.raises(ValueError, match=match):
+        get_default_policy_param_name(param, default_params_Policy)
+
+###############################################################################
+# Test to_json_reform
+
+def test_to_json_reform():
+    act, _ = to_json_reform(test_coverage_fields, START_YEAR)
+    np.testing.assert_equal(act, test_coverage_reform)
+
+###############################################################################
+# Test parse_errors_warnings
+REFORM_WARNINGS_ERRORS = {
+    u'policy': {
+        u'_STD_single': {u'2017': [7000.0]},
+        u'_FICA_ss_trt': {u'2017': [-1.0], u'2019': [0.1]},
+        u'_II_brk4_single': {u'2017': [500.0]},
+        u'_STD_headhousehold': {u'2017': [10000.0], u'2020': [150.0]},
+        u'_ID_BenefitSurtax_Switch_medical': {u'2017': [True]}
+    }
+}
+
+ERRORS = ("ERROR: 2017 _FICA_ss_trt value -1.0 < min value 0\n"
+          "ERROR: 2018 _FICA_ss_trt value -1.0 < min value 0\n"
+          "ERROR: 2017 _II_brk4_0 value 500.0 < min value 91900.0 for _II_brk3_0\n"
+          "ERROR: 2018 _II_brk4_0 value 511.1 < min value 93940.18 for _II_brk3_0\n"
+          "ERROR: 2019 _II_brk4_0 value 522.8 < min value 96091.41 for _II_brk3_0\n"
+          "ERROR: 2020 _II_brk4_0 value 534.98 < min value 98330.34 for _II_brk3_0\n"
+          "ERROR: 2021 _II_brk4_0 value 547.45 < min value 100621.44 for _II_brk3_0\n"
+          "ERROR: 2022 _II_brk4_0 value 560.15 < min value 102955.86 for _II_brk3_0\n"
+          "ERROR: 2023 _II_brk4_0 value 573.2 < min value 105354.73 for _II_brk3_0\n"
+          "ERROR: 2024 _II_brk4_0 value 586.56 < min value 107809.5 for _II_brk3_0\n"
+          "ERROR: 2025 _II_brk4_0 value 600.29 < min value 110332.24 for _II_brk3_0\n"
+          "ERROR: 2026 _II_brk4_0 value 614.4 < min value 112925.05 for _II_brk3_0\n")
+
+WARNINGS = ("WARNING: 2020 _STD_3 value 150.0 < min value 10004.23\n"
+            "WARNING: 2021 _STD_3 value 153.5 < min value 10237.33\n"
+            "WARNING: 2022 _STD_3 value 157.06 < min value 10474.84\n"
+            "WARNING: 2023 _STD_3 value 160.72 < min value 10718.9\n"
+            "WARNING: 2024 _STD_3 value 164.46 < min value 10968.65\n"
+            "WARNING: 2025 _STD_3 value 168.31 < min value 11225.32\n"
+            "WARNING: 2026 _STD_3 value 172.27 < min value 11489.12\n")
+
+ERRORS_WARNINGS = {'errors': ERRORS, 'warnings': WARNINGS}
+
+EXP_ERRORS_WARNINGS = {
+    'errors': {
+        '2024': {'II_brk4_0': 'ERROR: value 586.56 < min value 107809.5 for _II_brk3_0 for 2024'},
+        '2025': {'II_brk4_0': 'ERROR: value 600.29 < min value 110332.24 for _II_brk3_0 for 2025'},
+        '2026': {'II_brk4_0': 'ERROR: value 614.4 < min value 112925.05 for _II_brk3_0 for 2026'},
+        '2020': {'II_brk4_0': 'ERROR: value 534.98 < min value 98330.34 for _II_brk3_0 for 2020'},
+        '2018': {'FICA_ss_trt': 'ERROR: value -1.0 < min value 0 for 2018',
+                 'II_brk4_0': 'ERROR: value 511.1 < min value 93940.18 for _II_brk3_0 for 2018'},
+        '2022': {'II_brk4_0': 'ERROR: value 560.15 < min value 102955.86 for _II_brk3_0 for 2022'},
+        '2023': {'II_brk4_0': 'ERROR: value 573.2 < min value 105354.73 for _II_brk3_0 for 2023'},
+        '2019': {'II_brk4_0': 'ERROR: value 522.8 < min value 96091.41 for _II_brk3_0 for 2019'},
+        '2017': {'FICA_ss_trt': 'ERROR: value -1.0 < min value 0 for 2017',
+                 'II_brk4_0': 'ERROR: value 500.0 < min value 91900.0 for _II_brk3_0 for 2017'},
+        '2021': {'II_brk4_0': 'ERROR: value 547.45 < min value 100621.44 for _II_brk3_0 for 2021'}
+        },
+    'warnings': {
+        '2024': {'STD_3': 'WARNING: value 164.46 < min value 10968.65 for 2024'},
+        '2025': {'STD_3': 'WARNING: value 168.31 < min value 11225.32 for 2025'},
+        '2026': {'STD_3': 'WARNING: value 172.27 < min value 11489.12 for 2026'},
+        '2020': {'STD_3': 'WARNING: value 150.0 < min value 10004.23 for 2020'},
+        '2021': {'STD_3': 'WARNING: value 153.5 < min value 10237.33 for 2021'},
+        '2022': {'STD_3': 'WARNING: value 157.06 < min value 10474.84 for 2022'},
+        '2023': {'STD_3': 'WARNING: value 160.72 < min value 10718.9 for 2023'}
+    }
+}
+
+MAP_BACK_TO_TB = {
+    u'_STD_single': 'STD_0',
+    '_FICA_ss_trt': 'FICA_ss_trt',
+    u'_STD_headhousehold': 'STD_3',
+    u'_II_brk4_single': 'II_brk4_0',
+    u'_ID_BenefitSurtax_Switch_medical': 'ID_BenefitSurtax_Switch_0'
+}
+
+def test_parse_errors_warnings():
+    act = parse_errors_warnings(ERRORS_WARNINGS, MAP_BACK_TO_TB)
+    np.testing.assert_equal(EXP_ERRORS_WARNINGS, act)
+
+
+###############################################################################
+# Test read_json_reform
+@pytest.mark.parametrize(
+    ("test_reform,test_assump,map_back_to_tb,exp_reform,exp_assump,"
+     "exp_errors_warnings"),
+    [(test_coverage_json_reform, test_coverage_json_assumptions,
+      test_coverage_map_back_to_tb, test_coverage_exp_read_json_reform,
+      json.loads(test_coverage_json_assumptions),
+      {'errors': {}, 'warnings': {}}),
+      (test_coverage_json_reform, assumptions_text,
+        test_coverage_map_back_to_tb, test_coverage_exp_read_json_reform,
+        json.loads(assumptions_text),
+        {'errors': {}, 'warnings': {}}),
+     (REFORM_WARNINGS_ERRORS, test_coverage_json_assumptions, MAP_BACK_TO_TB,
+      False, json.loads(test_coverage_json_assumptions), ERRORS_WARNINGS)
+     ]
+)
+def test_read_json_reform(test_reform, test_assump, map_back_to_tb,
+                          exp_reform, exp_assump, exp_errors_warnings):
+    exp_assump = json.loads(test_coverage_json_assumptions)
+    exp_errors_warnings = {'errors': {}, 'warnings': {}}
+
+    act_reform, act_assump, act_errors_warnings = read_json_reform(
+        test_coverage_json_reform,
+        test_coverage_json_assumptions,
+        test_coverage_map_back_to_tb
+    )
+
+    np.testing.assert_equal(test_coverage_exp_read_json_reform, act_reform)
+    np.testing.assert_equal(exp_assump, act_assump)
+    np.testing.assert_equal(exp_errors_warnings, act_errors_warnings)

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -3,7 +3,7 @@ import pytest
 import taxcalc
 import numpy as np
 
-from ..taxbrain.views import get_reform_from_gui, get_reform_from_file
+from ..taxbrain.views import read_json_reform, parse_errors_warnings
 from ..taxbrain.helpers import (get_default_policy_param_name, to_json_reform)
 
 from test_reform import (test_coverage_fields, test_coverage_reform,

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -3,8 +3,7 @@ import pytest
 import taxcalc
 import numpy as np
 
-from ..taxbrain.views import (parse_errors_warnings, read_json_reform,
-                              get_reform_from_gui, get_reform_from_file)
+from ..taxbrain.views import get_reform_from_gui, get_reform_from_file
 from ..taxbrain.helpers import (get_default_policy_param_name, to_json_reform)
 
 from test_reform import (test_coverage_fields, test_coverage_reform,

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -44,15 +44,17 @@ def test_get_default_policy_param_name_failing0(param, default_params_Policy):
 
 def test_get_default_policy_param_name_failing1(default_params_Policy):
     param = "ID_BenefitSurtax_Switch_idx"
-    match="Parsing {0}: Index {0} not in range".format(param, "idx")
+    match = "Parsing {}: Expected integer for index but got {}".format(param, "idx")
     with pytest.raises(ValueError, match=match):
         get_default_policy_param_name(param, default_params_Policy)
 
 
 def test_get_default_policy_param_name_failing2(default_params_Policy):
     param = "ID_BenefitSurtax_Switch_12"
-    match="Parsing {}: Expected integer for index but got {}".format(param, "12")
-    with pytest.raises(ValueError, match=match):
+    # comment out "(" since this is treated as a regexp string
+    match = "Parsing {}: Index {} not in range \({}, {}\)"
+    match = match.format(param, 12, 0, 7)
+    with pytest.raises(IndexError, match=match):
         get_default_policy_param_name(param, default_params_Policy)
 
 ###############################################################################

--- a/webapp/apps/test_assets/test_reform.py
+++ b/webapp/apps/test_assets/test_reform.py
@@ -158,6 +158,24 @@ warning_reform = """
 }
 """
 
+"""
+    ********************************************************************
+    The following objects were created for test_param_formatters.py.
+
+    fields_base -- typical metadata associated with TaxBrain run
+
+    test_coverage_* objects -- these objects do not throw TC warnings or errors
+        but include a representative for each type of TC parameter in
+        current_law_policy.json
+
+    errors_warnings_* -- these objects do throw warnings and errors and include
+        a mostly representative set of TC parameters
+
+    map_back_to_tb -- required for mapping Tax-Calculator styled parameter
+        names to TaxBrain styled names
+    ********************************************************************
+"""
+
 fields_base = {
     '_state': "<django.db.models.base.ModelState object at 0x10c764950>",
     'creation_date': "datetime.datetime(2015, 1, 1, 0, 0)",

--- a/webapp/apps/test_assets/test_reform.py
+++ b/webapp/apps/test_assets/test_reform.py
@@ -157,3 +157,212 @@ warning_reform = """
     }
 }
 """
+
+test_coverage_fields = {
+    '_state': "<django.db.models.base.ModelState object at 0x10c764950>",
+    'creation_date': "datetime.datetime(2015, 1, 1, 0, 0)",
+    'id': 64,
+    'quick_calc': False,
+    'first_year': 2017,
+    'CG_nodiff': [False],
+    'FICA_ss_trt': [u'*', 0.1, u'*', 0.2],
+    'STD_0': [8000.0, '*', 10000.0],
+    'ID_BenefitSurtax_Switch_0': [True],
+    'ID_Charity_c_cpi': True,
+    'EITC_rt_2': [1.0]
+}
+
+test_coverage_reform = {
+    '_CG_nodiff': {'2017': [False]},
+    '_FICA_ss_trt': {'2020': [0.2], '2018': [0.1]},
+    '_STD_single': {'2017': [8000.0], '2019': [10000.0]},
+    '_ID_Charity_c_cpi': {'2017': True},
+    '_ID_BenefitSurtax_Switch_medical': {'2017': [True]},
+    '_EITC_rt_2kids': {'2017': [1.0]}
+}
+
+test_coverage_map_back_to_tb = {
+
+}
+
+
+test_coverage_json_reform = """
+{
+    "policy": {
+        "_ID_BenefitSurtax_Switch_charity": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_ALD_InvInc_ec_base_RyanBrady": {
+            "2017": [
+                false
+            ]
+        },
+        "_ID_BenefitSurtax_Switch_interest": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_EITC_indiv": {
+            "2017": [
+                false
+            ]
+        },
+        "_ID_BenefitSurtax_Switch_misc": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_ID_BenefitCap_Switch_charity": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_STD_single": {
+            "2017": [
+                10000.0
+            ]
+        },
+        "_II_no_em_nu18": {
+            "2017": [
+                false
+            ]
+        },
+        "_ID_BenefitSurtax_Switch_realestate": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_ID_BenefitCap_Switch_misc": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_CG_nodiff": {
+            "2017": [
+                false
+            ]
+        },
+        "_ID_BenefitSurtax_Switch_statelocal": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_ID_BenefitCap_Switch_medical": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_FICA_ss_trt": {
+            "2020": [
+                0.2
+            ],
+            "2018": [
+                0.1
+            ]
+        },
+        "_ID_BenefitCap_Switch_casualty": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_ID_Charity_c_cpi": {
+            "2017": true
+        },
+        "_ID_BenefitCap_Switch_statelocal": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_EITC_rt_2kids": {
+            "2017": [
+                1.0
+            ]
+        },
+        "_ID_BenefitSurtax_Switch_casualty": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_NIIT_PT_taxed": {
+            "2017": [
+                false
+            ]
+        },
+        "_ID_BenefitSurtax_Switch_medical": {
+            "2017": [
+                1.0
+            ]
+        },
+        "_ID_BenefitCap_Switch_interest": {
+            "2017": [
+                0.0
+            ]
+        },
+        "_CTC_new_refund_limited": {
+            "2017": [
+                false
+            ]
+        },
+        "_ID_BenefitCap_Switch_realestate": {
+            "2017": [
+                0.0
+            ]
+        }
+    }
+}
+"""
+
+test_coverage_json_assumptions = """
+{
+    "growdiff_response": {},
+    "consumption": {},
+    "behavior": {},
+    "growdiff_baseline": {}
+}
+"""
+
+test_coverage_map_back_to_tb = {
+    u'_ID_BenefitSurtax_Switch_charity': 'ID_BenefitSurtax_Switch_6',
+    '_ALD_InvInc_ec_base_RyanBrady': 'ALD_InvInc_ec_base_RyanBrady',
+    u'_ID_BenefitSurtax_Switch_interest': 'ID_BenefitSurtax_Switch_5',
+    '_EITC_indiv': 'EITC_indiv',
+    u'_ID_BenefitSurtax_Switch_misc': 'ID_BenefitSurtax_Switch_4',
+    u'_ID_BenefitCap_Switch_charity': 'ID_BenefitCap_Switch_6',
+    u'_STD_single': 'STD_0',
+    '_II_no_em_nu18': 'II_no_em_nu18',
+    u'_ID_BenefitSurtax_Switch_realestate': 'ID_BenefitSurtax_Switch_2',
+    u'_ID_BenefitCap_Switch_misc': 'ID_BenefitCap_Switch_4',
+    '_CG_nodiff': 'CG_nodiff',
+    u'_ID_BenefitSurtax_Switch_statelocal': 'ID_BenefitSurtax_Switch_1',
+    u'_ID_BenefitCap_Switch_medical': 'ID_BenefitCap_Switch_0',
+    '_FICA_ss_trt': 'FICA_ss_trt',
+    u'_ID_BenefitCap_Switch_casualty': 'ID_BenefitCap_Switch_3',
+    '_ID_Charity_c_cpi': 'ID_Charity_c_cpi',
+    u'_ID_BenefitCap_Switch_statelocal': 'ID_BenefitCap_Switch_1',
+    u'_EITC_rt_2kids': 'EITC_rt_2',
+    u'_ID_BenefitSurtax_Switch_casualty': 'ID_BenefitSurtax_Switch_3',
+    '_NIIT_PT_taxed': 'NIIT_PT_taxed',
+    u'_ID_BenefitSurtax_Switch_medical': 'ID_BenefitSurtax_Switch_0',
+    u'_ID_BenefitCap_Switch_interest': 'ID_BenefitCap_Switch_5',
+    '_CTC_new_refund_limited': 'CTC_new_refund_limited',
+    u'_ID_BenefitCap_Switch_realestate': 'ID_BenefitCap_Switch_2'
+}
+
+
+test_coverage_exp_read_json_reform = {
+    2017: {u'_EITC_rt': [[0.0765, 0.34, 1.0, 0.45]],
+           u'_NIIT_PT_taxed': [False],
+           u'_ID_BenefitCap_Switch': [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+           u'_ALD_InvInc_ec_base_RyanBrady': [False],
+           u'_EITC_indiv': [False],
+           u'_ID_BenefitSurtax_Switch': [[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+           u'_STD': [[10000.0, 12700.0, 6350.0, 9350.0, 12700.0]],
+           u'_II_no_em_nu18': [False],
+           u'_ID_Charity_c_cpi': True,
+           u'_CG_nodiff': [False],
+           u'_CTC_new_refund_limited': [False]},
+    2018: {u'_FICA_ss_trt': [0.1]},
+    2020: {u'_FICA_ss_trt': [0.2]}
+}

--- a/webapp/apps/test_assets/test_reform.py
+++ b/webapp/apps/test_assets/test_reform.py
@@ -323,7 +323,7 @@ test_coverage_json_assumptions = """
 }
 """
 
-test_coverage_map_back_to_tb = {
+map_back_to_tb = {
     u'_ID_BenefitSurtax_Switch_charity': 'ID_BenefitSurtax_Switch_6',
     '_ALD_InvInc_ec_base_RyanBrady': 'ALD_InvInc_ec_base_RyanBrady',
     u'_ID_BenefitSurtax_Switch_interest': 'ID_BenefitSurtax_Switch_5',
@@ -347,9 +347,11 @@ test_coverage_map_back_to_tb = {
     u'_ID_BenefitSurtax_Switch_medical': 'ID_BenefitSurtax_Switch_0',
     u'_ID_BenefitCap_Switch_interest': 'ID_BenefitCap_Switch_5',
     '_CTC_new_refund_limited': 'CTC_new_refund_limited',
-    u'_ID_BenefitCap_Switch_realestate': 'ID_BenefitCap_Switch_2'
+    u'_ID_BenefitCap_Switch_realestate': 'ID_BenefitCap_Switch_2',
+    u'_STD_single': 'STD_0',
+    u'_STD_headhousehold': 'STD_3',
+    u'_II_brk4_single': 'II_brk4_0'
 }
-
 
 test_coverage_exp_read_json_reform = {
     2017: {u'_EITC_rt': [[0.0765, 0.34, 1.0, 0.45]],

--- a/webapp/apps/test_assets/test_reform.py
+++ b/webapp/apps/test_assets/test_reform.py
@@ -158,19 +158,23 @@ warning_reform = """
 }
 """
 
-test_coverage_fields = {
+fields_base = {
     '_state': "<django.db.models.base.ModelState object at 0x10c764950>",
     'creation_date': "datetime.datetime(2015, 1, 1, 0, 0)",
     'id': 64,
     'quick_calc': False,
     'first_year': 2017,
-    'CG_nodiff': [False],
-    'FICA_ss_trt': [u'*', 0.1, u'*', 0.2],
-    'STD_0': [8000.0, '*', 10000.0],
-    'ID_BenefitSurtax_Switch_0': [True],
-    'ID_Charity_c_cpi': True,
-    'EITC_rt_2': [1.0]
 }
+
+test_coverage_fields = dict(
+    CG_nodiff = [False],
+    FICA_ss_trt = [u'*', 0.1, u'*', 0.2],
+    STD_0 = [8000.0, '*', 10000.0],
+    ID_BenefitSurtax_Switch_0 = [True],
+    ID_Charity_c_cpi = True,
+    EITC_rt_2 = [1.0],
+    **fields_base
+)
 
 test_coverage_reform = {
     '_CG_nodiff': {'2017': [False]},
@@ -181,147 +185,23 @@ test_coverage_reform = {
     '_EITC_rt_2kids': {'2017': [1.0]}
 }
 
-test_coverage_map_back_to_tb = {
+errors_warnings_fields = dict(
+        STD_0 = [7000.0],
+        FICA_ss_trt = [-1.0,'*',0.1],
+        II_brk4_0 = [500.0],
+        STD_3= [10000.0, '*', '*', 150.0],
+        ID_BenefitSurtax_Switch_0= [True],
+        **fields_base
+)
 
+errors_warnings_reform = {
+    u'_STD_single': {u'2017': [7000.0]},
+    u'_FICA_ss_trt': {u'2017': [-1.0], u'2019': [0.1]},
+    u'_II_brk4_single': {u'2017': [500.0]},
+    u'_STD_headhousehold': {u'2017': [10000.0], u'2020': [150.0]},
+    u'_ID_BenefitSurtax_Switch_medical': {u'2017': [True]}
 }
 
-
-test_coverage_json_reform = """
-{
-    "policy": {
-        "_ID_BenefitSurtax_Switch_charity": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_ALD_InvInc_ec_base_RyanBrady": {
-            "2017": [
-                false
-            ]
-        },
-        "_ID_BenefitSurtax_Switch_interest": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_EITC_indiv": {
-            "2017": [
-                false
-            ]
-        },
-        "_ID_BenefitSurtax_Switch_misc": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_ID_BenefitCap_Switch_charity": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_STD_single": {
-            "2017": [
-                10000.0
-            ]
-        },
-        "_II_no_em_nu18": {
-            "2017": [
-                false
-            ]
-        },
-        "_ID_BenefitSurtax_Switch_realestate": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_ID_BenefitCap_Switch_misc": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_CG_nodiff": {
-            "2017": [
-                false
-            ]
-        },
-        "_ID_BenefitSurtax_Switch_statelocal": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_ID_BenefitCap_Switch_medical": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_FICA_ss_trt": {
-            "2020": [
-                0.2
-            ],
-            "2018": [
-                0.1
-            ]
-        },
-        "_ID_BenefitCap_Switch_casualty": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_ID_Charity_c_cpi": {
-            "2017": true
-        },
-        "_ID_BenefitCap_Switch_statelocal": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_EITC_rt_2kids": {
-            "2017": [
-                1.0
-            ]
-        },
-        "_ID_BenefitSurtax_Switch_casualty": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_NIIT_PT_taxed": {
-            "2017": [
-                false
-            ]
-        },
-        "_ID_BenefitSurtax_Switch_medical": {
-            "2017": [
-                1.0
-            ]
-        },
-        "_ID_BenefitCap_Switch_interest": {
-            "2017": [
-                0.0
-            ]
-        },
-        "_CTC_new_refund_limited": {
-            "2017": [
-                false
-            ]
-        },
-        "_ID_BenefitCap_Switch_realestate": {
-            "2017": [
-                0.0
-            ]
-        }
-    }
-}
-"""
-
-test_coverage_json_assumptions = """
-{
-    "growdiff_response": {},
-    "consumption": {},
-    "behavior": {},
-    "growdiff_baseline": {}
-}
-"""
 
 map_back_to_tb = {
     u'_ID_BenefitSurtax_Switch_charity': 'ID_BenefitSurtax_Switch_6',
@@ -353,6 +233,49 @@ map_back_to_tb = {
     u'_II_brk4_single': 'II_brk4_0'
 }
 
+test_coverage_json_reform = """
+{
+    "policy": {
+        "_ID_BenefitSurtax_Switch_charity": {"2017": [0.0]},
+        "_ALD_InvInc_ec_base_RyanBrady": {"2017": [false]},
+        "_ID_BenefitSurtax_Switch_interest": {"2017": [0.0]},
+        "_EITC_indiv": {"2017": [false]},
+        "_ID_BenefitSurtax_Switch_misc": {"2017": [0.0]},
+        "_ID_BenefitCap_Switch_charity": {"2017": [0.0]},
+        "_STD_single": {"2017": [10000.0]},
+        "_II_no_em_nu18": {"2017": [false]},
+        "_ID_BenefitSurtax_Switch_realestate": {"2017": [0.0]},
+        "_ID_BenefitCap_Switch_misc": {"2017": [0.0]},
+        "_CG_nodiff": {"2017": [false]},
+        "_ID_BenefitSurtax_Switch_statelocal": {"2017": [0.0]},
+        "_ID_BenefitCap_Switch_medical": {"2017": [0.0]},
+        "_FICA_ss_trt": {"2020": [0.2], "2018": [0.1]},
+        "_ID_BenefitCap_Switch_casualty": {"2017": [0.0]},
+        "_ID_Charity_c_cpi": {"2017": true},
+        "_ID_BenefitCap_Switch_statelocal": {"2017": [0.0]},
+        "_EITC_rt_2kids": {"2017": [1.0]},
+        "_ID_BenefitSurtax_Switch_casualty": {"2017": [0.0]},
+        "_NIIT_PT_taxed": {"2017": [false]},
+        "_ID_BenefitSurtax_Switch_medical": {"2017": [1.0]},
+        "_ID_BenefitCap_Switch_interest": {"2017": [0.0]},
+        "_CTC_new_refund_limited": {"2017": [false]},
+        "_ID_BenefitCap_Switch_realestate": {"2017": [0.0]}
+    }
+}
+"""
+
+errors_warnings_json_reform = """
+{
+    "policy": {
+    "_ID_BenefitSurtax_Switch_medical": {"2017": [true]},
+    "_STD_headhousehold": {"2017": [10000.0], "2020": [150.0]},
+    "_FICA_ss_trt": {"2017": [-1.0], "2019": [0.1]},
+    "_STD_single": {"2017": [7000.0]},
+    "_II_brk4_single": {"2017": [500.0]}
+    }
+}
+"""
+
 test_coverage_exp_read_json_reform = {
     2017: {u'_EITC_rt': [[0.0765, 0.34, 1.0, 0.45]],
            u'_NIIT_PT_taxed': [False],
@@ -367,4 +290,64 @@ test_coverage_exp_read_json_reform = {
            u'_CTC_new_refund_limited': [False]},
     2018: {u'_FICA_ss_trt': [0.1]},
     2020: {u'_FICA_ss_trt': [0.2]}
+}
+
+
+errors_warnings_exp_read_json_reform = {
+    2017:
+        {u'_II_brk4': [[500.0, 233350.0, 116675.0, 212500.0, 233350.0]],
+        u'_STD': [[7000.0, 12700.0, 6350.0, 10000.0, 12700.0]],
+        u'_ID_BenefitSurtax_Switch': [[True, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]],
+        u'_FICA_ss_trt': [-1.0]},
+    2019: {u'_FICA_ss_trt': [0.1]},
+    2020: {u'_STD': [[7489.8, 13588.64, 6794.31, 150.0, 13588.64]]}
+}
+
+errors = ("ERROR: 2017 _FICA_ss_trt value -1.0 < min value 0\n"
+          "ERROR: 2018 _FICA_ss_trt value -1.0 < min value 0\n"
+          "ERROR: 2017 _II_brk4_0 value 500.0 < min value 91900.0 for _II_brk3_0\n"
+          "ERROR: 2018 _II_brk4_0 value 511.1 < min value 93940.18 for _II_brk3_0\n"
+          "ERROR: 2019 _II_brk4_0 value 522.8 < min value 96091.41 for _II_brk3_0\n"
+          "ERROR: 2020 _II_brk4_0 value 534.98 < min value 98330.34 for _II_brk3_0\n"
+          "ERROR: 2021 _II_brk4_0 value 547.45 < min value 100621.44 for _II_brk3_0\n"
+          "ERROR: 2022 _II_brk4_0 value 560.15 < min value 102955.86 for _II_brk3_0\n"
+          "ERROR: 2023 _II_brk4_0 value 573.2 < min value 105354.73 for _II_brk3_0\n"
+          "ERROR: 2024 _II_brk4_0 value 586.56 < min value 107809.5 for _II_brk3_0\n"
+          "ERROR: 2025 _II_brk4_0 value 600.29 < min value 110332.24 for _II_brk3_0\n"
+          "ERROR: 2026 _II_brk4_0 value 614.4 < min value 112925.05 for _II_brk3_0\n")
+
+warnings = ("WARNING: 2020 _STD_3 value 150.0 < min value 10004.23\n"
+            "WARNING: 2021 _STD_3 value 153.5 < min value 10237.33\n"
+            "WARNING: 2022 _STD_3 value 157.06 < min value 10474.84\n"
+            "WARNING: 2023 _STD_3 value 160.72 < min value 10718.9\n"
+            "WARNING: 2024 _STD_3 value 164.46 < min value 10968.65\n"
+            "WARNING: 2025 _STD_3 value 168.31 < min value 11225.32\n"
+            "WARNING: 2026 _STD_3 value 172.27 < min value 11489.12\n")
+
+errors_warnings = {'errors': errors, 'warnings': warnings}
+
+exp_errors_warnings = {
+    'errors': {
+        '2024': {'II_brk4_0': 'ERROR: value 586.56 < min value 107809.5 for _II_brk3_0 for 2024'},
+        '2025': {'II_brk4_0': 'ERROR: value 600.29 < min value 110332.24 for _II_brk3_0 for 2025'},
+        '2026': {'II_brk4_0': 'ERROR: value 614.4 < min value 112925.05 for _II_brk3_0 for 2026'},
+        '2020': {'II_brk4_0': 'ERROR: value 534.98 < min value 98330.34 for _II_brk3_0 for 2020'},
+        '2018': {'FICA_ss_trt': 'ERROR: value -1.0 < min value 0 for 2018',
+                 'II_brk4_0': 'ERROR: value 511.1 < min value 93940.18 for _II_brk3_0 for 2018'},
+        '2022': {'II_brk4_0': 'ERROR: value 560.15 < min value 102955.86 for _II_brk3_0 for 2022'},
+        '2023': {'II_brk4_0': 'ERROR: value 573.2 < min value 105354.73 for _II_brk3_0 for 2023'},
+        '2019': {'II_brk4_0': 'ERROR: value 522.8 < min value 96091.41 for _II_brk3_0 for 2019'},
+        '2017': {'FICA_ss_trt': 'ERROR: value -1.0 < min value 0 for 2017',
+                 'II_brk4_0': 'ERROR: value 500.0 < min value 91900.0 for _II_brk3_0 for 2017'},
+        '2021': {'II_brk4_0': 'ERROR: value 547.45 < min value 100621.44 for _II_brk3_0 for 2021'}
+        },
+    'warnings': {
+        '2024': {'STD_3': 'WARNING: value 164.46 < min value 10968.65 for 2024'},
+        '2025': {'STD_3': 'WARNING: value 168.31 < min value 11225.32 for 2025'},
+        '2026': {'STD_3': 'WARNING: value 172.27 < min value 11489.12 for 2026'},
+        '2020': {'STD_3': 'WARNING: value 150.0 < min value 10004.23 for 2020'},
+        '2021': {'STD_3': 'WARNING: value 153.5 < min value 10237.33 for 2021'},
+        '2022': {'STD_3': 'WARNING: value 157.06 < min value 10474.84 for 2022'},
+        '2023': {'STD_3': 'WARNING: value 160.72 < min value 10718.9 for 2023'}
+    }
 }


### PR DESCRIPTION
This PR adds unit tests for functions introduced in PR #641 and related PRs.  Tests were added for the following functions:
1. [`taxbrain.helpers.get_default_policy_param_name`](https://github.com/OpenSourcePolicyCenter/PolicyBrain/blob/master/webapp/apps/taxbrain/helpers.py#L260)--Two minor bugs were discovered while adding tests and they will be fixed in subsequent commits
2. [`taxbrain.helpers.to_json_reform`](https://github.com/OpenSourcePolicyCenter/PolicyBrain/blob/master/webapp/apps/taxbrain/helpers.py#L290)
3. [`taxbrain.helpers.parse_errors_warnings`](https://github.com/OpenSourcePolicyCenter/PolicyBrain/blob/master/webapp/apps/taxbrain/views.py#L152)
4. [`taxbrain.views.read_json_reform`](https://github.com/OpenSourcePolicyCenter/PolicyBrain/blob/master/webapp/apps/taxbrain/views.py#L181)

I intended to add tests for the `taxbrain.views.get_reform_from_gui` and `taxbrain.views.get_reform_from_file` functions, but this appears to require the mocking of `PersonalExemptionForm`, `TaxSaveInputs`, and `request` objects.  I think I'm going to table this for another PR unless someone has an idea for how this could be done more easily.
