### PR TITLE
Reinstate ogusa

### DIFF
--- a/templates/dynamic/dynamic_input_form.html
+++ b/templates/dynamic/dynamic_input_form.html
@@ -61,11 +61,6 @@
               <div class="sidebar-button">
                 <a href="#" ></a>
                 <input id="tax-submit" class="btn btn-secondary btn-block btn-animate {{ is_disabled }}" {{ is_disabled }} type="submit" value="Start Dynamic Simulation!">
-                <div class="construction text-center">
-                  <div class="progress progress-striped" style="width: 100%">
-                    <div class="progress-bar active progress-bar-custom" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
-                  </div>
-                </div>
               </div>
             </div> <!-- sidebar -->
           </div>

--- a/templates/dynamic/landing.html
+++ b/templates/dynamic/landing.html
@@ -72,21 +72,14 @@
                       {% flatblock "dynamic_behavioral_blurb" %}
                     </td>
                 </tr>
-                {% if include_ogusa %}
                 <tr padding="15px">
                     <td>
-                    <a href="/dynamic/ogusa/{{pk}}/?start_year={{start_year}}" class="text-white btn btn-secondary disabled">Overlapping Generations Simulation</a>
+                    <a href="/dynamic/ogusa/{{pk}}/?start_year={{start_year}}" class="text-white btn btn-secondary">Overlapping Generations Simulation</a>
                     </td>
                     <td>
-                      <div class="construction">
-                        <div class="progress progress-striped" style="min-width: 400px; width: 100%">
-                          <div class="progress-bar active progress-bar-custom" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
-                        </div>
-                      </div>
                       {% flatblock "dynamic_olg_blurb" %}
                     </td>
                 </tr>
-                {% endif %}
                 <tr padding="15px">
                     <td padding-bottom="1em">
                      <a href="/dynamic/macro/{{pk}}/?start_year={{start_year}}" class="text-white btn btn-secondary">Macro Elasticities Simulation</a>

--- a/webapp/apps/dynamic/compute.py
+++ b/webapp/apps/dynamic/compute.py
@@ -7,7 +7,6 @@ import requests_mock
 import taxcalc
 from ..taxbrain.compute import DropqCompute, MockCompute
 from .models import OGUSAWorkerNodesCounter
-from .helpers import filter_ogusa_only
 from ..constants import START_YEAR
 
 dqversion_info = taxcalc._version.get_versions()
@@ -33,15 +32,8 @@ class DynamicCompute(DropqCompute):
         response = requests.post(theurl, data=data, timeout=timeout)
         return response
 
-    def submit_ogusa_calculation(self, ogusa_mods, first_budget_year, microsim_data):
-        print "mods is ", ogusa_mods
-        ogusa_params = filter_ogusa_only(ogusa_mods)
-        data = {}
-        data['taxio_format'] = True
-        data['first_budget_year'] = first_budget_year
-        microsim_params = microsim_data
-
-
+    def submit_ogusa_calculation(self, data):
+        print "mods is ", data
         print "submit dynamic work"
 
         hostnames = OGUSA_WORKERS
@@ -50,9 +42,6 @@ class DynamicCompute(DropqCompute):
             'callback': "http://{}/dynamic/dynamic_finished".format(CALLBACK_HOSTNAME),
         }
 
-        data['ogusa_params'] = json.dumps(ogusa_params)
-        data['user_mods'] = json.dumps(microsim_params)
-        data['first_year'] = first_budget_year
         job_ids = []
         guids = []
 

--- a/webapp/apps/dynamic/compute.py
+++ b/webapp/apps/dynamic/compute.py
@@ -33,25 +33,13 @@ class DynamicCompute(DropqCompute):
         response = requests.post(theurl, data=data, timeout=timeout)
         return response
 
-    def submit_json_ogusa_calculation(self, ogusa_mods, first_budget_year,
-                                      microsim_data, pack_up_user_mods):
-        return self.submit_ogusa_calculation(ogusa_mods, first_budget_year,
-                                             microsim_data, pack_up_user_mods=False)
-
-    def submit_ogusa_calculation(self, ogusa_mods, first_budget_year, microsim_data,
-                                 pack_up_user_mods=True):
-
+    def submit_ogusa_calculation(self, ogusa_mods, first_budget_year, microsim_data):
         print "mods is ", ogusa_mods
         ogusa_params = filter_ogusa_only(ogusa_mods)
         data = {}
-        if pack_up_user_mods:
-            microsim_params = package_up_vars(microsim_data, first_budget_year)
-            microsim_params = {first_budget_year:microsim_params}
-            print "microsim data is", microsim_params
-        else:
-            data['taxio_format'] = True
-            data['first_budget_year'] = first_budget_year
-            microsim_params = microsim_data
+        data['taxio_format'] = True
+        data['first_budget_year'] = first_budget_year
+        microsim_params = microsim_data
 
 
         print "submit dynamic work"

--- a/webapp/apps/dynamic/helpers.py
+++ b/webapp/apps/dynamic/helpers.py
@@ -209,7 +209,7 @@ def filter_ogusa_only(user_values):
             print "Removing ", k, v
             del user_values[k]
         else:
-            user_values[k] = float(v)
+            user_values[k] = float(v[0]) if isinstance(v, list) else float(v)
 
     return user_values
 

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -45,7 +45,8 @@ from .helpers import (default_parameters, job_submitted,
                       failure_text, normalize, denormalize, strip_empty_lists,
                       cc_text_finished, cc_text_failure, dynamic_params_from_model,
                       send_cc_email, default_behavior_parameters,
-                      elast_results_to_tables, default_elasticity_parameters)
+                      elast_results_to_tables, default_elasticity_parameters,
+                      filter_ogusa_only)
 
 from .compute import DynamicCompute
 
@@ -115,12 +116,18 @@ def dynamic_input(request, pk):
 
             else:
                 reform_dict = json.loads(taxbrain_model.json_text.reform_text)
-            print(reform_dict)
-            print(worker_data)
+
+            ogusa_params = filter_ogusa_only(worker_data)
+            data = {
+                'taxio_format': True,
+                'first_budget_year': int(start_year),
+                'ogusa_params': json.dumps(ogusa_params),
+                'user_mods': json.dumps(reform_dict),
+                'first_year': int(start_year)
+            }
+
             submitted_ids, guids = dynamic_compute.submit_ogusa_calculation(
-                worker_data,
-                int(start_year),
-                reform_dict
+                data
             )
 
             # TODO: use OutputUrl class


### PR DESCRIPTION
This PR reinstates OG-USA on TaxBrain.  In doing so, the input processing logic for the `dynamic/views.py` function `dyanamic_input` was changed so that it used the input processing logic introduced in PR #641.   Further, the input processing that was done in `DynamicCompute.submit_ogusa_calculation` is now done in `dynamic_input`.