### PR TITLE
Add Brown-Khanna Gain Act of 2017 preset

### DIFF
--- a/templates/taxbrain/input_form.html
+++ b/templates/taxbrain/input_form.html
@@ -214,6 +214,7 @@
                   <li>Brady-Ryan Plan (<a href = "//www.ospc.org/taxbrain/edit/13337/?start_year=2017" target="_blank">Reform</a>,  <a href = "//docs.google.com/document/d/1ZWePr-l-KaLOf8RPt3dbfAkiK-dzztYqs711BtfeS_c/edit?usp=sharing" target="_blank">Notes</a>)</li>
                   <li>Trump 2016 Campaign (<a href = "//www.ospc.org/taxbrain/edit/11178/?start_year=2017" target="_blank">Reform</a>,  <a href = "//docs.google.com/document/d/1QicaAeWdSgwGEWWRxIkjegyAq4lakoMklFhVHzwIukM/edit?usp=sharing" target="_blank">Notes</a>)</li>
                   <li>2017 Trump Administration (<a href = "//www.ospc.org/taxbrain/edit/11522/?start_year=2017" target="_blank">Reform</a>,  <a href = "//docs.google.com/document/d/1Cum1NU6nP_a0v3-Ro7MKJYeNkaBeGRKKqBrTnAqi0_Q/edit?usp=sharing" target="_blank">Notes</a>)</li>
+                  <li>Brown-Khanna GAIN Act of 2017 (<a href = "https://www.ospc.org/taxbrain/edit/19212/?start_year=2017" target="_blank">Reform</a>, <a href = "https://docs.google.com/document/d/1lmxHhJ_FYCiN3x84G9LU25fRs5gxiRlfX7AmXBjCG5w/edit?usp=sharing" target="_blank">Notes</a>)</li>
                   </ul>
 
                   <div>


### PR DESCRIPTION
Closes #704. This adds a preset for the Brown-Khanna Gain Act of 2017.  This is based off of @martinholmer and @MattHJensen's work in PR open-source-economics/Tax-Calculator#1555.  The notes file is based off of @martinholmer's work in open-source-economics/Tax-Calculator#1607.  

This PR follows the admittedly sub-optimal process of keeping the reform notes in a Google doc.  In the near future, a better solution needs to be found.