### PR TITLE
Fix "news.ospc.org" link bug

### DIFF
--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -68,7 +68,7 @@
                 </ul>
             </li>
             <li class="{% if section.active_nav == 'news' %}current{% endif %}">
-              <a href="//news.ospc.org">News</a>
+              <a href="http://news.ospc.org/">News</a>
             </li>
             <li class="{% if section.active_nav == 'about' %}current{% endif %}">
               <a href="/about">About OSPC</a>

--- a/templates/pages/home_content.html
+++ b/templates/pages/home_content.html
@@ -132,13 +132,13 @@
   <section class="news-items news-items-dark">
     <div class="container">
       <p class="text-right">
-        <a href="//news.ospc.org" class="see-all">See all news</a>
+        <a href="http://news.ospc.org/" class="see-all">See all news</a>
       </p>
       <div class="row">
         <div class="col-sm-6 col-sm-offset-3">
           <div class="news-item tagged">
             <h4>
-              <a href="//news.ospc.org/welcome-to-ospc.html">Welcome to OSPC</a>
+              <a href="http://news.ospc.org/welcome-to-ospc.html">Welcome to OSPC</a>
             </h4>
             <p>
               The Open Source Policy Center is making policy analysis more


### PR DESCRIPTION
This PR closes #727. 

The Policy Brain app is not able to find `news.ospc.org` without supplying a full hyper link, for the reason that the blog (news) page is hosted somewhere else outside the app. 

There's no way for me to test on my local (the previous link works just fine on local as well as on test app). I used console to substitute HTML elements on [ospc.org](https://www.ospc.org/) by hard-coding, and it seems that, after making the following changes, the website has no problem accessing `news.ospc.org`.

@hdoupe @MattHJensen 