### PR TITLE
Remove UBI exclude statement

### DIFF
--- a/templates/taxbrain/input_form.html
+++ b/templates/taxbrain/input_form.html
@@ -152,9 +152,7 @@
                 <li class="get-started"><a href="#get-started">Get Started</a></li>
                   {% for param in params %}
                     {% for key, value in param.items %}
-                      {% if key != "ubi" %}
-                        <li><a href="#{{ key|make_id }}">{{ key }}</a></li>
-                      {% endif %}
+                      <li><a href="#{{ key|make_id }}">{{ key }}</a></li>
                     {% endfor %}
                   {% endfor %}
               </ul>


### PR DESCRIPTION
This PR removes a no longer needed UBI conditional statement.  It looks like this was added to keep the UBI parameter from showing up in the GUI input page.  However, we want the UBI params to show up now.  Further, it doesn't look like it actually did anything.  See #746 