### PR TITLE
Change job_proc_time from 30 to 50 seconds

### DIFF
--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -63,7 +63,7 @@ tcversion_info = taxcalc._version.get_versions()
 
 TAXCALC_VERSION = tcversion_info['version']
 
-JOB_PROC_TIME_IN_SECONDS = 30
+JOB_PROC_TIME_IN_SECONDS = 50
 
 OUT_OF_RANGE_ERROR_MSG = ("Some fields have errors. Values outside of suggested "
                           "ranges will be accepted if they only cause warnings "


### PR DESCRIPTION
Resolves #750 

50 seconds was chosen since the webapp takes about 40 seconds to run one year of static analysis.  This should be a safe amount of time to allow for one year's calculation.