### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+A working group of community members is committed to promptly addressing any
+reported issues. The working group is made up of pandas contributors and users.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the working group by e-mail (email@email.com).
+Messages sent to this e-mail address will not be publicly visible but only to
+the working group members. The working group currently includes
+
+- ...
+
+All complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
+
+This Code of Conduct was created by [pandas][pandascoc] developers, who
+adapted it from the [Contributor Covenant][homepage], version 1.3.0, available
+at [http://contributor-covenant.org/version/1/3/0/][version],
+and the [Swift Code of Conduct][swift].
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/
+[swift]: https://swift.org/community/#code-of-conduct
+[pandascoc]: https://github.com/pandas-dev/pandas-governance/blob/master/code-of-conduct.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -48,9 +48,9 @@ that is deemed necessary and appropriate to the circumstances. Maintainers are
 obligated to maintain confidentiality with regard to the reporter of an
 incident.
 
-This Code of Conduct was created by [pandas][pandascoc] developers, who
-adapted it from the [Contributor Covenant][homepage], version 1.3.0, available
-at [http://contributor-covenant.org/version/1/3/0/][version],
+This Code of Conduct was copied from the [pandas Code of Conduct][pandas_coc]
+which was adapted from the [Contributor Covenant][homepage], version 1.3.0,
+available at [http://contributor-covenant.org/version/1/3/0/][version],
 and the [Swift Code of Conduct][swift].
 
 [homepage]: http://contributor-covenant.org


### PR DESCRIPTION
In this PR, I propose adding a Code of Conduct for PolicyBrain.  The goal is to ensure that this environment remains open and welcoming for contributors from all walks of life and levels of technical expertise.  From following threads in other projects and reading about successful open source projects, I think that having a Code of Conduct where misbehaving or simply frustrated members can be referred is an easy, painless way to keep discussions from devolving into ad hominem attacks or other non-productive means of debate.

The Code of Conduct proposed here was copied from [pandas](https://github.com/pandas-dev/pandas-governance/blob/master/code-of-conduct.md).  I welcome and encourage all feedback on this document.  

If we decide to keep the working group, then I volunteer myself to be in it.  If you are interested in being in this working group, then please indicate this by leaving a comment below.  Ideally, we would have 2-4 members in this group.