### PR TITLE
Make sure ID_AmountCap_Switch param is submitted as 1/0

### DIFF
--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -58,6 +58,7 @@ class TaxBrainViewsTests(TestCase):
         del data[u'ID_BenefitSurtax_Switch_4']
         del data[u'ID_BenefitSurtax_Switch_6']
         data[u'II_em'] = [u'4333']
+        data[u'ID_AmountCap_Switch_0'] = [u'True']
 
         wnc, created = WorkerNodesCounter.objects.get_or_create(singleton_enforce=1)
         current_dropq_worker_offset = wnc.current_offset
@@ -73,6 +74,8 @@ class TaxBrainViewsTests(TestCase):
         # Check that data was saved properly
         truth_mods = {START_YEAR: {"_ID_BenefitSurtax_Switch":
                                    [[0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0]],
+                                   "_ID_AmountCap_Switch":
+                                   [[1, 0, 0, 0, 0, 0, 0]],
                                    "_II_em": [4333.0]}
                       }
         check_posted_params(result['tb_dropq_compute'], truth_mods,

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -270,6 +270,10 @@ def get_reform_from_gui(request, taxbrain_model=None, behavior_model=None,
                                              taxbrain_data,
                                              taxbrain_model,
                                              name="ID_BenefitCap_Switch")
+        taxbrain_data = benefit_switch_fixup(request.REQUEST,
+                                             taxbrain_data,
+                                             taxbrain_model,
+                                             name="ID_AmountCap_Switch")
         taxbrain_data = amt_fixup(request.REQUEST,
                                   taxbrain_data,
                                   taxbrain_model)


### PR DESCRIPTION
This PR simply changes the parameter formatting.  For unknown reasons, sometimes parameters get swapped from 0 to `False` or from 1 to `True`.  Using the `benefit_switch_fixup` function ensures uniform formatting of this type of parameter:

<img width="755" alt="screen shot 2017-11-30 at 10 35 51 am" src="https://user-images.githubusercontent.com/9206065/33438972-48c1aa7c-d5ba-11e7-87be-c686ca413732.png">
