### PR TITLE
Fix file upload page redirect issue 

### DIFF
--- a/templates/taxbrain/file_base.html
+++ b/templates/taxbrain/file_base.html
@@ -86,7 +86,7 @@
   <script src="{% static 'js/vendor/share-button/share-button.min.js' %}"></script>
   <!-- Scripts -->
   <script src="{% static 'js/site.js' %}"></script>
-  <script src="{% static 'js/taxbrain.js' %}"></script>
+  <script src="{% static 'js/filetb.js' %}"></script>
   <script src="{% static 'js/forms.js' %}"></script>
   <script type="text/javascript">
     $('.what-is a').click(function() {

--- a/templates/taxbrain/input_file.html
+++ b/templates/taxbrain/input_file.html
@@ -1,4 +1,4 @@
-{% extends 'taxbrain/input_base.html' %}
+{% extends 'taxbrain/file_base.html' %}
 
 {% load staticfiles %}
 


### PR DESCRIPTION
This PR closes #760. The problem being identified is that correct javascript file is not being properly rendered. In particular, before this PR, some code in `input_base.html` reads:

```
  {% if input_type == "file" %}
  <script src="{% static 'js/filetb.js' %}"></script>
  {% else %}
  <script src="{% static 'js/taxbrain.js' %}"></script>
  {% endif %}
```

The if loop here, however, will always fall into the `else` clause, and thus causing #760. 

An easy yet inelegant solution would be having two separate templates for `input_form.html` and `input_file.html`, which is what I used in this PR. 

While working out more concise and elegant solution, it'd also be a good idea to test this PR on test server. 

@hdoupe @MattHJensen 

