### PR TITLE
Add input_type back to context

### DIFF
--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -576,7 +576,8 @@ def file_input(request):
         'params': None,
         'start_years': START_YEARS,
         'start_year': start_year,
-        'enable_quick_calc': ENABLE_QUICK_CALC
+        'enable_quick_calc': ENABLE_QUICK_CALC,
+        'input_type': "file"
     }
 
     return render(request, 'taxbrain/input_file.html', init_context)


### PR DESCRIPTION
@GoFroggyRun's comment in PR #760 led me to this solution.  In particular, @GoFroggyRun said:

> In particular, before this PR, some code in input_base.html reads:
> ```
>   {% if input_type == "file" %}
>   <script src="{% static 'js/filetb.js' %}"></script>
>   {% else %}
>   <script src="{% static 'js/taxbrain.js' %}"></script>
>   {% endif %}
> ```
> The if loop here, however, will always fall into the else clause, and thus causing #760.

In PR #641, I removed this from the context.  Sometimes I do things that are both extremely frustrating and highly amusing.  This happens to be one of them.  Check out this [comment](https://github.com/OpenSourcePolicyCenter/PolicyBrain/commit/85183a88bc593361eb1a1a240b01a8d070d06d3a#diff-8bfe9696ea1ed6a7d52dfb5455a2f47bR341):
![screen shot 2017-12-08 at 3 34 22 pm](https://user-images.githubusercontent.com/9206065/33784049-4b165b8c-dc2d-11e7-8284-882aad1e38cd.png)
