### PR TITLE
Convert DependentCredit_before_CTC from bool to int

### DIFF
--- a/webapp/apps/btax/forms.py
+++ b/webapp/apps/btax/forms.py
@@ -3,12 +3,12 @@ from django.forms import ModelForm
 from django.utils.translation import ugettext_lazy as _
 
 from .models import BTaxSaveInputs
-from .helpers import (BTaxField, BTaxParam, get_btax_defaults)
+from .helpers import (BTaxField, BTaxParam, get_btax_defaults,
+                      convert_val, make_bool)
 from ..taxbrain.helpers import (is_number, int_to_nth,
                                 is_string, string_to_float_array,
                                 check_wildcards, expand_list,
-                                propagate_user_list, convert_val,
-                                make_bool)
+                                propagate_user_list)
 import taxcalc
 
 from ..taxbrain.forms import (has_field_errors,

--- a/webapp/apps/btax/helpers.py
+++ b/webapp/apps/btax/helpers.py
@@ -210,3 +210,17 @@ def group_args_to_btax_depr(btax_default_params, asset_yr_str):
 
             )
     return depr_argument_groups
+
+
+def make_bool(x):
+    b = True if x == 'True' else False
+    return b
+
+
+def convert_val(x):
+    if is_wildcard(x):
+        return x
+    try:
+        return float(x)
+    except ValueError:
+        return make_bool(x)

--- a/webapp/apps/btax/views.py
+++ b/webapp/apps/btax/views.py
@@ -38,11 +38,10 @@ from .models import BTaxSaveInputs, BTaxOutputUrl
 from .helpers import (get_btax_defaults,
                       BTAX_BITR, BTAX_DEPREC,
                       BTAX_OTHER, BTAX_ECON,
-                      group_args_to_btax_depr, hover_args_to_btax_depr)
+                      group_args_to_btax_depr, hover_args_to_btax_depr,
+                      make_bool, convert_val)
 from ..taxbrain.helpers import (format_csv,
-                                is_wildcard,
-                                convert_val,
-                                make_bool)
+                                is_wildcard)
 from ..taxbrain.views import (benefit_switch_fixup,
                               denormalize, normalize)
 from .compute import DropqComputeBtax, MockComputeBtax, JobFailError

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -302,7 +302,6 @@ class PersonalExemptionForm(ModelForm):
             "_CTC_new_refund_limited_all_payroll",
             "_PT_wages_active_income",
             "_PT_top_stacking",
-            "_DependentCredit_before_CTC"
         ]
 
         for param in TAXCALC_DEFAULTS_2016.values():

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -93,7 +93,7 @@ def parse_fields(param_dict):
         if v == u'' or v is None or v == []:
             del param_dict[k]
             continue
-        if type(v) == type(unicode()): #TODO: isinstance(value, unicode)
+        if isinstance(v, six.string_types):
             param_dict[k] = [convert_val(x) for x in v.split(',') if x]
     return param_dict
 

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -65,22 +65,9 @@ def make_bool(x):
     Returns True for True or 1
     Returns False for False or 0
     """
-    if not isinstance(x, (bool, six.string_types, unicode)):
-        try:
-            if np.allclose(float(x), 0.0):
-                return False
-            elif np.allclose(float(x), 1.0):
-                return True
-            else:
-                pass
-        except Exception as e:
-            pass #raises type error below
-        raise TypeError(
-            "Expected string but got {}".format(type(x))
-        )
-    if x is True:
+    if x in (True, '1', '1.0', 1, 1.0):
         return True
-    elif x is False:
+    elif x in (False, '0', '0.0', 0, 0.0):
         return False
     elif TRUE_REGEX.match(x, endpos=4):
         return True

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import numbers
 import os
 import pandas as pd
+import numpy as np
 import pyparsing as pp
 import sys
 import time
@@ -61,8 +62,19 @@ def check_wildcards(x):
 def make_bool(x):
     """
     Find exact match for case insensitive true or false
+    Returns True for True or 1
+    Returns False for False or 0
     """
-    if not isinstance(x, (bool, six.string_types, unicode)):# or not isinstance(x, six.string_types):
+    if not isinstance(x, (bool, six.string_types, unicode)):
+        try:
+            if np.allclose(float(x), 0.0):
+                return False
+            elif np.allclose(float(x), 1.0):
+                return True
+            else:
+                pass
+        except Exception as e:
+            pass #raises type error below
         raise TypeError(
             "Expected string but got {}".format(type(x))
         )

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -25,6 +25,8 @@ SPECIAL_INFLATABLE_PARAMS = {'_II_credit', '_II_credit_ps'}
 SPECIAL_NON_INFLATABLE_PARAMS = {'_ACTC_ChildNum', '_EITC_MinEligAge',
                                  '_EITC_MaxEligAge'}
 
+BOOL_PARAMS = ['DependentCredit_before_CTC']
+
 # Grammar for Field inputs
 TRUE = pp.CaselessKeyword('true')
 FALSE = pp.CaselessKeyword('false')
@@ -64,8 +66,11 @@ def make_bool(x):
     Find exact match for case insensitive true or false
     Returns True for True or 1
     Returns False for False or 0
+    If x is wildcard then simply return x
     """
-    if x in (True, '1', '1.0', 1, 1.0):
+    if is_wildcard(x):
+        return x
+    elif x in (True, '1', '1.0', 1, 1.0):
         return True
     elif x in (False, '0', '0.0', 0, 0.0):
         return False
@@ -94,7 +99,11 @@ def parse_fields(param_dict):
             del param_dict[k]
             continue
         if isinstance(v, six.string_types):
-            param_dict[k] = [convert_val(x) for x in v.split(',') if x]
+            if k in BOOL_PARAMS:
+                converter = make_bool
+            else:
+                converter = convert_val
+            param_dict[k] = [converter(x) for x in v.split(',') if x]
     return param_dict
 
 def int_to_nth(x):

--- a/webapp/apps/taxbrain/migrations/0060_auto_20171219_2153.py
+++ b/webapp/apps/taxbrain/migrations/0060_auto_20171219_2153.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import webapp.apps.taxbrain.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taxbrain', '0059_auto_20171216_2123'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='taxsaveinputs',
+            name='DependentCredit_before_CTC',
+            field=webapp.apps.taxbrain.models.CommaSeparatedField(default=None, max_length=200, null=True, blank=True),
+        ),
+    ]

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -553,7 +553,7 @@ class TaxSaveInputs(models.Model):
     CTC_new_c = CommaSeparatedField(default=None, blank=True, null=True)
     CTC_new_c_under5_bonus = CommaSeparatedField(default=None, blank=True, null=True)
     CTC_new_for_all = models.CharField(default="False", blank=True, null=True, max_length=50)
-    DependentCredit_before_CTC = models.CharField(default="False", blank=True, null=True, max_length=50)
+    DependentCredit_before_CTC = CommaSeparatedField(default=None, blank=True, null=True)
     ACTC_rt = CommaSeparatedField(default=None, blank=True, null=True)
     ACTC_ChildNum = CommaSeparatedField(default=None, blank=True, null=True)
     ACTC_rt_bonus_under5family = CommaSeparatedField(default=None, blank=True, null=True)

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -33,9 +33,11 @@ def convert_to_floats(tsi):
     attrs = vars(tsi)
     return { k:numberfy(v) for k,v in attrs.items() if v}
 
+# digit or true/false (case insensitive)
+COMMASEP_REGEX = "(\\d*\\.\\d+|\\d+)|((?i)(true|false))"
 
 class CommaSeparatedField(models.CharField):
-    default_validators = [validators.RegexValidator(regex='\d*\.\d+|\d+')]
+    default_validators = [validators.RegexValidator(regex="(\\d*\\.\\d+|\\d+)|((?i)(true|false))")]
     description = "A comma separated field that allows multiple floats."
 
     def __init__(self, verbose_name=None, name=None, **kwargs):

--- a/webapp/apps/taxbrain/tests/test_helpers.py
+++ b/webapp/apps/taxbrain/tests/test_helpers.py
@@ -150,16 +150,16 @@ def test_parsing_fail():
 @pytest.mark.parametrize(
     'item,exp',
     [('True', True), ('true', True), ('TRUE', True), (True, True),
-     ('tRue', True), (1.0, True),
+     ('tRue', True), (1.0, True), (1, True), ('1.0', True), ('1', True),
      ('False', False), ('false', False), ('FALSE', False), (False, False),
-     ('faLSe', False), (0, False)]
+     ('faLSe', False), (0.0, False), (0, False), ('0.0', False), ('0', False)]
 )
 def test_make_bool(item, exp):
     assert make_bool(item) is exp
 
 @pytest.mark.parametrize(
     'item',
-    ['abc', '0', '1', 10]
+    ['abc', 10, '10', '00', 2]
 )
 def test_make_bool_fail(item):
     with pytest.raises((ValueError, TypeError)):

--- a/webapp/apps/taxbrain/tests/test_helpers.py
+++ b/webapp/apps/taxbrain/tests/test_helpers.py
@@ -150,16 +150,16 @@ def test_parsing_fail():
 @pytest.mark.parametrize(
     'item,exp',
     [('True', True), ('true', True), ('TRUE', True), (True, True),
-     ('tRue', True),
+     ('tRue', True), (1.0, True),
      ('False', False), ('false', False), ('FALSE', False), (False, False),
-     ('faLSe', False)]
+     ('faLSe', False), (0, False)]
 )
 def test_make_bool(item, exp):
     assert make_bool(item) is exp
 
 @pytest.mark.parametrize(
     'item',
-    ['abc', '0', '1', 1, 10]
+    ['abc', '0', '1', 10]
 )
 def test_make_bool_fail(item):
     with pytest.raises((ValueError, TypeError)):

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -408,7 +408,7 @@ class TaxBrainViewsTests(TestCase):
         # Check that data was submitted properly
         truth_mods = {
             2018: {'_DependentCredit_before_CTC': [True]},
-            2020: {'_DependentCredit_before_CTC': [False],
+            2020: {'_DependentCredit_before_CTC': [False]},
             2021: {'_DependentCredit_before_CTC': [True]}
         }
         check_posted_params(result['tb_dropq_compute'], truth_mods,

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -401,7 +401,7 @@ class TaxBrainViewsTests(TestCase):
         string
         """
         data = get_post_data(2018, _ID_BenefitSurtax_Switches=False)
-        data['DependentCredit_before_CTC'] = [u'True,*,FALSE,tRUe']
+        data['DependentCredit_before_CTC'] = [u'True,*,FALSE,tRUe,*,0']
 
         result = do_micro_sim(self.client, data)
 
@@ -409,7 +409,8 @@ class TaxBrainViewsTests(TestCase):
         truth_mods = {
             2018: {'_DependentCredit_before_CTC': [True]},
             2020: {'_DependentCredit_before_CTC': [False]},
-            2021: {'_DependentCredit_before_CTC': [True]}
+            2021: {'_DependentCredit_before_CTC': [True]},
+            2023: {'_DependentCredit_before_CTC': [False]}
         }
         check_posted_params(result['tb_dropq_compute'], truth_mods,
                             str(2018))

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -395,6 +395,25 @@ class TaxBrainViewsTests(TestCase):
         self.assertEqual(response.status_code, 200)
         assert response.context['has_errors'] is True
 
+    def test_taxbrain_bool_separated_values(self):
+        """
+        Test _DependentCredit_before_CTC can be posted as comma separated
+        string
+        """
+        data = get_post_data(2018, _ID_BenefitSurtax_Switches=False)
+        data['DependentCredit_before_CTC'] = [u'True,*,FALSE,tRUe']
+
+        result = do_micro_sim(self.client, data)
+
+        # Check that data was submitted properly
+        truth_mods = {
+            2018: {'_DependentCredit_before_CTC': [True]},
+            2020: {'_DependentCredit_before_CTC': [False],
+            2021: {'_DependentCredit_before_CTC': [True]}
+        }
+        check_posted_params(result['tb_dropq_compute'], truth_mods,
+                            str(2018))
+
 
     def test_taxbrain_rt_capital_gain_goes_to_amt(self):
         """


### PR DESCRIPTION
Resolves #765.  This PR treats `DependentCredit_before_CTC` as an integer instead of a boolean parameter which allows the user to very the parameter's value over time.

EDIT:
Old behavior:
![screen shot 2017-12-19 at 5 12 11 pm](https://user-images.githubusercontent.com/9206065/34181544-8d28ae6a-e4e0-11e7-9136-ab20f3d75ec1.png)

New behavior:
![screen shot 2017-12-19 at 5 12 49 pm](https://user-images.githubusercontent.com/9206065/34181564-a7723d2c-e4e0-11e7-8b16-41e86d52fcc5.png)
