### PR TITLE
Convert default values for boolean parameters from 1/0 to "True"/"False"

### DIFF
--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -809,6 +809,18 @@ class TaxCalcParam(object):
         # organize defaults by column [[A1,B1],[A2,B2]] to [[A1,A2],[B1,B2]]
         values_by_col = [list(x) for x in zip(*values_by_year)]
 
+        # Tax-Calculator converts boolean values to 1/0 via
+        # np.array(bool_val, np.int8)
+        # here we convert that value back to a boolean type and serialize it
+        if self.nice_id in BOOL_PARAMS:
+            if isinstance(values_by_col, list) and isinstance(values_by_col[0], list):
+                for i in range(len(values_by_col[0])):
+                    values_by_col[0][i] = str(make_bool(values_by_col[0][i]))
+            elif isinstance(values_by_col, list):
+                for i in range(len(values_by_col[0])):
+                    values_by_col[i] = str(make_bool(values_by_col[i]))
+            else:
+                values_by_col = str(make_bool(values_by_col[i]))
         #
         # normalize and format column labels
         #
@@ -861,11 +873,11 @@ class TaxCalcParam(object):
             self.inflatable = attributes['inflatable']
         elif self.tc_id in inflatable_params:
             self.inflatable = True
-        elif self.tc_id in non_inflatable_params:
+        elif (self.tc_id in non_inflatable_params or
+              self.nice_id in BOOL_PARAMS):
             self.inflatable = False
         else:
             self.inflatable = first_value > 1
-
 
         if self.inflatable:
             cpi_flag = attributes['cpi_inflated']

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -103,7 +103,7 @@ def parse_fields(param_dict):
                 converter = make_bool
             else:
                 converter = convert_val
-            param_dict[k] = [converter(x) for x in v.split(',') if x]
+            param_dict[k] = [converter(x.strip()) for x in v.split(',') if x]
     return param_dict
 
 def int_to_nth(x):

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -813,14 +813,10 @@ class TaxCalcParam(object):
         # np.array(bool_val, np.int8)
         # here we convert that value back to a boolean type and serialize it
         if self.nice_id in BOOL_PARAMS:
-            if isinstance(values_by_col, list) and isinstance(values_by_col[0], list):
-                for i in range(len(values_by_col[0])):
-                    values_by_col[0][i] = str(make_bool(values_by_col[0][i]))
-            elif isinstance(values_by_col, list):
-                for i in range(len(values_by_col[0])):
-                    values_by_col[i] = str(make_bool(values_by_col[i]))
-            else:
-                values_by_col = str(make_bool(values_by_col[i]))
+            assert (isinstance(values_by_col, list) and
+                    isinstance(values_by_col[0], list))
+            for i in range(len(values_by_col[0])):
+                values_by_col[0][i] = str(make_bool(values_by_col[0][i]))
         #
         # normalize and format column labels
         #

--- a/webapp/apps/taxbrain/tests/test_helpers.py
+++ b/webapp/apps/taxbrain/tests/test_helpers.py
@@ -3,7 +3,8 @@ import json
 import numpy as np
 import taxcalc
 import pyparsing as pp
-from ..helpers import nested_form_parameters, rename_keys, INPUT, make_bool
+from ..helpers import (nested_form_parameters, rename_keys, INPUT, make_bool,
+                       TaxCalcParam)
 
 CURRENT_LAW_POLICY = """
 {
@@ -164,3 +165,55 @@ def test_make_bool(item, exp):
 def test_make_bool_fail(item):
     with pytest.raises((ValueError, TypeError)):
         make_bool(item)
+
+
+def test_make_taxcalc_param():
+    """
+    Test creation of taxcalc param from comma separated boolean value
+    """
+    name =  u'_DependentCredit_before_CTC'
+    attr = {
+        u'integer_value': True,
+        u'start_year': 2017,
+        u'description': 'test',
+        u'out_of_range_action': u'stop',
+        u'col_var': u'',
+        u'long_name': u'test',
+        u'out_of_range_maxmsg': u'',
+        u'row_var': u'FLPDYR',
+        u'cpi_inflated': False,
+        u'boolean_value': True,
+        u'col_label': u'',
+        u'out_of_range_minmsg': u'',
+        u'notes': u'',
+        u'value': [0],
+        u'section_1': u'Nonrefundable Credits',
+        u'irs_ref': u'',
+        u'range': {u'min': False, u'max': True},
+        u'section_2': u'Child Tax Credit',
+        u'row_label': ['2017']
+    }
+    budget_year = 2017
+    use_puf_not_cps = True
+
+    param = TaxCalcParam(name, attr, budget_year, use_puf_not_cps)
+    field = param.col_fields[0]
+    assert field.values == ['False']
+
+    attr['value'] = [0, 0, 1]
+    param = TaxCalcParam(name, attr, budget_year, use_puf_not_cps)
+    fields = param.col_fields
+    for field, exp in zip(fields, ['False', 'False', 'True']):
+        assert field.values == [exp]
+
+    attr['value'] = [0, 0, 1]
+    param = TaxCalcParam(name, attr, budget_year, use_puf_not_cps)
+    fields = param.col_fields
+    for field, exp in zip(fields, ['False', 'False', 'True']):
+        assert field.values == [exp]
+
+    attr['value'] = [[0, 0, 1]]
+    param = TaxCalcParam(name, attr, budget_year, use_puf_not_cps)
+    fields = param.col_fields
+    for field, exp in zip(fields, ['False', 'False', 'True']):
+        assert field.values == [exp]

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -401,7 +401,7 @@ class TaxBrainViewsTests(TestCase):
         string
         """
         data = get_post_data(2018, _ID_BenefitSurtax_Switches=False)
-        data['DependentCredit_before_CTC'] = [u'True,*,FALSE,tRUe,*,0']
+        data['DependentCredit_before_CTC'] = [u'True,*, FALSE,tRUe,*,0']
 
         result = do_micro_sim(self.client, data)
 


### PR DESCRIPTION
This PR converts 1/0 values back to boolean variables and serializes them.  PolicyBrain reads the default GUI parameter values from Tax-Calculator's [`default_data`](https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/parameters.py#L24) function.  This [line in parameters.py](https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/parameters.py#L438) converts boolean parameters from true/false to 1/0.  This treatment is currently only applied to `DependentCredit_before_CTC` but will be applied to the other comma separated boolean variables as they are added.

Before this PR, the default parameter value for `DependentCredit_before_CTC` was shown as:
![screen shot 2017-12-21 at 5 52 17 pm](https://user-images.githubusercontent.com/9206065/34278255-b6451df4-e677-11e7-80f4-b3186a42231e.png)

Behavior introduced by this PR shows:
![screen shot 2017-12-21 at 5 53 14 pm](https://user-images.githubusercontent.com/9206065/34278292-d75442e0-e677-11e7-9077-8546b58848ec.png)

