### PR TITLE
Add reverse operator

### DIFF
--- a/templates/taxbrain/input_form.html
+++ b/templates/taxbrain/input_form.html
@@ -192,6 +192,7 @@
                   <strong>DO NOT</strong> use commas as thousands separators. </li>
                   <li> Express rates as decimals. </li>
                   <li>You can represent a value that would otherwise manifest itself in a year with the <strong>*</strong> operator. So, for example, if you enter <strong>0.1, *, 0.2</strong> in a tax rate field, the rate will be 10 percent in the Start Year, 10 percent a year after the Start Year, and 20 percent two years after the Start Year and forward. If you enter <strong>100, *, 200</strong> in a CPI-indexed field for a credit amount, the credit will be $100 in the Start Year, $100*(1+CPI) the next year, and $200 the following year.</li>
+                  <li>You may specify a parameter change in the year before the Start Year with the <strong> < </strong> operator. For example, if you set the Start Year as 2018 and a Parameter Indexing Offset parameter to <strong> <,-0.0025,-0.001 </strong> then this sets the Offset to -0.0025 in 2017 and -0.001 in 2018.</li>
                   <li> <a href = "//ospc.org/docs" target="_blank">Read the Docs</a> </li>
                   <li> <a href = "//docs.google.com/forms/d/e/1FAIpQLSfvKEsQZNe9_16FhKNZcEyv3C8qXZhBfrqLxSd4VR97w92moQ/viewform" target="_blank">Leave Feedback</a> </li>
                   </ul>

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -275,11 +275,12 @@ class PersonalExemptionForm(ModelForm):
                     continue
 
                 submitted_col_values_raw = self.cleaned_data[col_field.id]
-
                 if len(submitted_col_values_raw) > 0 and submitted_col_values_raw not in BOOLEAN_FLAGS:
                     try:
                         INPUT.parseString(submitted_col_values_raw)
-                    except ParseException as pe:
+                        # reverse character is not at the beginning
+                        assert submitted_col_values_raw.find('<') <= 0
+                    except (ParseException, AssertionError):
                         # Parse Error - we don't recognize what they gave us
                         self.add_error(col_field.id, "Unrecognized value: {}".format(submitted_col_values_raw))
 

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -410,6 +410,7 @@ def to_json_reform(fields, start_year, cls=taxcalc.Policy):
     returns json style reform
     """
     map_back_to_tb = {}
+    number_reverse_operators = 1
     default_params = cls.default_data(start_year=start_year,
                                       metadata=True)
     ignore = (u'has_errors', u'csrfmiddlewaretoken', u'start_year',
@@ -436,18 +437,22 @@ def to_json_reform(fields, start_year, cls=taxcalc.Policy):
                 elif is_reverse(fields[param][i]):
                     # only the first character can be a reverse char
                     # and there must be a following character
-                    assert i == 0 and len(fields[param]) > 1
+                    assert len(fields[param]) > 1
                     # set value for parameter in start_year - 1
                     assert (isinstance(fields[param][i + 1], (int, float)) or
                             isinstance(fields[param][i + 1], bool))
-                    reform[param_name][str(start_year - 1)] = [fields[param][i + 1]]
-                    # skip next year
-                    i += 2
+                    reform[param_name][str(start_year - 1)] = \
+                        [fields[param][i + 1]]
+
+                    # realign year and parameter indices
+                    for op in (0, number_reverse_operators + 1):
+                        fields[param].pop(0)
                     continue
                 else:
                     assert (isinstance(fields[param][i], (int, float)) or
                             isinstance(fields[param][i], bool))
-                    reform[param_name][str(start_year + i)] = [fields[param][i]]
+                    reform[param_name][str(start_year + i)] = \
+                        [fields[param][i]]
 
                 i += 1
 

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -37,7 +37,7 @@ def convert_to_floats(tsi):
 COMMASEP_REGEX = "(\\d*\\.\\d+|\\d+)|((?i)(true|false))"
 
 class CommaSeparatedField(models.CharField):
-    default_validators = [validators.RegexValidator(regex="(\\d*\\.\\d+|\\d+)|((?i)(true|false))")]
+    default_validators = [validators.RegexValidator(regex="(<,)|(\\d*\\.\\d+|\\d+)|((?i)(true|false))")]
     description = "A comma separated field that allows multiple floats."
 
     def __init__(self, verbose_name=None, name=None, **kwargs):

--- a/webapp/apps/taxbrain/tests/test_helpers.py
+++ b/webapp/apps/taxbrain/tests/test_helpers.py
@@ -3,7 +3,8 @@ import json
 import numpy as np
 import taxcalc
 import pyparsing as pp
-from ..helpers import nested_form_parameters, rename_keys, INPUT, make_bool
+from ..helpers import (nested_form_parameters, rename_keys, INPUT, make_bool,
+                       is_reverse)
 
 CURRENT_LAW_POLICY = """
 {
@@ -138,12 +139,14 @@ def test_rename_keys(monkeypatch):
      'False', 'false', 'FALSE','faLSe',
      'true,*', '*, true', '*,*,false',
      'true,*,false,*,*,true',
-     '1,*,False', '0.0,True', '1.0,False']
+     '1,*,False', '0.0,True', '1.0,False',
+     '<,True', '<,1']
 )
 def test_parsing_pass(item):
     INPUT.parseString(item)
 
-def test_parsing_fail():
+@pytest.mark.parametrize('item', ['abc', '<,', '<', '1,<', '0,<,1', 'True,<', '-0.002,<,-0.001'])
+def test_parsing_fail(item):
     with pytest.raises(pp.ParseException):
         INPUT.parseString('abc')
 
@@ -164,3 +167,9 @@ def test_make_bool(item, exp):
 def test_make_bool_fail(item):
     with pytest.raises((ValueError, TypeError)):
         make_bool(item)
+
+@pytest.mark.parametrize(
+    'item,exp',
+    [('<', True), ('a', False), ('1', False), (1, False), (False, False)])
+def test_is_reverse(item, exp):
+    assert is_reverse(item) is exp

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -798,7 +798,8 @@ def edit_personal_results(request, pk):
         'webapp_version': webapp_vers_disp,
         'start_years': START_YEARS,
         'start_year': str(start_year),
-        'is_edit_page': True
+        'is_edit_page': True,
+        'has_errors': False
     }
 
     return render(request, 'taxbrain/input_form.html', init_context)

--- a/webapp/apps/test_assets/test_reform.py
+++ b/webapp/apps/test_assets/test_reform.py
@@ -204,8 +204,10 @@ fields_base = {
 }
 
 test_coverage_fields = dict(
+    cpi_offset = ['<', -0.0025],
     CG_nodiff = [False],
-    FICA_ss_trt = [u'*', 0.1, u'*', 0.2],
+    FICA_ss_trt = ['<',0.1,'*',0.15,0.2],
+    FICA_mc_trt = ['<',0.1,0.15],
     STD_0 = [8000.0, '*', 10000.0],
     ID_BenefitSurtax_Switch_0 = [True],
     ID_Charity_c_cpi = True,
@@ -214,8 +216,10 @@ test_coverage_fields = dict(
 )
 
 test_coverage_reform = {
+    '_cpi_offset': {'2016': [-0.0025]},
     '_CG_nodiff': {'2017': [False]},
-    '_FICA_ss_trt': {'2020': [0.2], '2018': [0.1]},
+    '_FICA_ss_trt': {'2016': [0.1], '2018': [0.15], '2019': [0.2]},
+    '_FICA_mc_trt': {'2016': [0.1], '2017': [0.15]},
     '_STD_single': {'2017': [8000.0], '2019': [10000.0]},
     '_ID_Charity_c_cpi': {'2017': True},
     '_ID_BenefitSurtax_Switch_medical': {'2017': [True]},
@@ -267,7 +271,8 @@ map_back_to_tb = {
     u'_ID_BenefitCap_Switch_realestate': 'ID_BenefitCap_Switch_2',
     u'_STD_single': 'STD_0',
     u'_STD_headhousehold': 'STD_3',
-    u'_II_brk4_single': 'II_brk4_0'
+    u'_II_brk4_single': 'II_brk4_0',
+    u'_cpi_offset': 'cpi_offset'
 }
 
 test_coverage_json_reform = """


### PR DESCRIPTION
This PR adds the reverse operator discussed in issue #763. 

Basic rules as described in this [comment](https://github.com/OpenSourcePolicyCenter/PolicyBrain/issues/763#issuecomment-353669184) in #763 :
> I think we should impose some strict rules on how this symbol can be used so that we can keep everything simple.
> 
> 1. It can only be used at the beginning of the string.
> 2. It can only send a parameter back one year (this rule could be relaxed fairly easily)
> 
> For example, if you set the start year as 2018 and the cpi_offset parameter to "<,-0.0025", then this sets the cpi_offset to -0.0025 in 2017.

