### PR TITLE
Saves start year after warnings are shown for file upload

### DIFF
--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -568,6 +568,7 @@ def file_input(request):
     has_errors = False
     if request.method == 'POST':
         # File is not submitted
+        start_year = request.REQUEST['start_year']
         if 'docfile' not in dict(request.FILES) and form_id is None:
             errors = ["Please specify a tax-law change before submitting."]
             json_reform = None

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -567,8 +567,9 @@ def file_input(request):
     errors = []
     has_errors = False
     if request.method == 'POST':
-        # File is not submitted
+        # save start_year
         start_year = request.REQUEST['start_year']
+        # File is not submitted
         if 'docfile' not in dict(request.FILES) and form_id is None:
             errors = ["Please specify a tax-law change before submitting."]
             json_reform = None


### PR DESCRIPTION
This PR preserves the start year after a file is uploaded and warnings are shown.  Prior to this PR, the start year was wiped out after the warnings/errors were shown for a file upload.