### PR TITLE
.travis.yml update to fix build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
   # Install conda
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - pushd deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
+  - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
   - pushd deploy
   - ./install_taxbrain_server.sh
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
   # Install conda
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'

--- a/do_nothing.txt
+++ b/do_nothing.txt
@@ -1,0 +1,1 @@
+do_nothing

--- a/do_nothing.txt
+++ b/do_nothing.txt
@@ -1,1 +1,0 @@
-do_nothing


### PR DESCRIPTION
We've been getting the following error when travis does a PolicyBrain build after a PR is merged or a new version is released:
![screen shot 2018-01-11 at 10 04 33 am](https://user-images.githubusercontent.com/9206065/34832078-dc8d2f16-f6b6-11e7-8b64-271b9ab8c625.png)

https://travis-ci.org/OpenSourcePolicyCenter/PolicyBrain/builds/327422754?utm_source=github_status&utm_medium=notification

This stems from travis-ci/travis-ci#4704.  The patch was provided in this comment: https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959

I tested the patch by opening the following PR on my PolicyBrain fork: hdoupe/PolicyBrain#5