### PR TITLE
Small changes to .gitignore and install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ dump.rdb
 *.pem
 
 _build
+
+.DS_Store
+*.egg-info
+staticfiles
+

--- a/deploy/install_taxbrain_server.sh
+++ b/deploy/install_taxbrain_server.sh
@@ -23,7 +23,7 @@ install_reqs(){
     echo Install requirements.txt of the deploy folder;
     pip install -r requirements.txt || return 1;
     pip uninstall -y taxbrain_server &> /dev/null;
-    python setup.py develop || return 1;
+    pip install -e . || return 1;
     rm -rf taxbrain_server/logs
     mkdir taxbrain_server/logs || return 1;
     return 0;


### PR DESCRIPTION
Explanation:

- `.DS_Store` - Useless file created by Mac file browser
- `.egg-info` - Created when doing pip install
- `staticfiles` - Migrated staticfiles, should probably be ignored
- `pip install -e .` - Safer / more consistent version of `python setup.py develop`

I talked to @hdoupe about my regular schedule now so expect commits around this time MWF/Sat/Sun.