### PR TITLE
Changed all instances of TJ Alumbaugh's email address

### DIFF
--- a/templates/dynamic/behavior.html
+++ b/templates/dynamic/behavior.html
@@ -100,7 +100,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/dynamic/dynamic_input_form.html
+++ b/templates/dynamic/dynamic_input_form.html
@@ -99,7 +99,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/dynamic/elasticity.html
+++ b/templates/dynamic/elasticity.html
@@ -99,7 +99,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/dynamic/elasticity_results.html
+++ b/templates/dynamic/elasticity_results.html
@@ -98,7 +98,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/dynamic/landing.html
+++ b/templates/dynamic/landing.html
@@ -100,7 +100,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/dynamic/results.html
+++ b/templates/dynamic/results.html
@@ -98,7 +98,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/pages/apps.html
+++ b/templates/pages/apps.html
@@ -93,7 +93,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/taxbrain/header.html
+++ b/templates/taxbrain/header.html
@@ -163,7 +163,7 @@
         <p><strong>
         Core Maintainers (static modeling)*:
         <ul style = "list-style-type:none">
-        <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+        <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
         <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
         <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
         <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/taxbrain/input_file.html
+++ b/templates/taxbrain/input_file.html
@@ -103,7 +103,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>

--- a/templates/taxbrain/input_form.html
+++ b/templates/taxbrain/input_form.html
@@ -104,7 +104,7 @@
             <p><strong>
             Core Maintainers (static modeling)*:
             <ul style = "list-style-type:none">
-            <li>- <a href = "https://www.continuum.io/content/tj-alumbaugh" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
+            <li>- <a href = "https://github.com/talumbau" target = "blank" >T.J. Alumbaugh, Continuum Analytics</a></li>
             <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg, National Bureau of Economic Research</a></li>
             <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer, Policy Simulation Group</a></li>
             <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen, American Enterprise Institute</a></li>


### PR DESCRIPTION
Fix for https://github.com/OpenSourcePolicyCenter/PolicyBrain/issues/815

Hmm... Turns out there's a lot of repeated things that are kind of a mess to maintain. I was thinking that a good way to unify the "text-heavy" parts of this project would be to use something like Jekyll, so that the texts of like the "about" parts could be written first in Markdown then built to HTML, which would be much cleaner than just writing everything in HTML (as it currently stands). For example, disclaimers and stuff that is used frequently throughout multiple apps could be written once, so that if they have to be updated somewhere down the line it is cleaner / safer than running some complicated grep. For example, you can put peoples' emails in a yaml file so that they can be updated / referenced more easily...

The Jekyll stuff wouldn't add very much technical complexity / likelihood of breaking things, since it's just a static markdown renderer (i.e. renders to HTML templates). Design would be something like:

Add a subdirectory in the project devoted to static includes (i.e. `jekyll-templates/`) with two subdirectories, `src/` and `generated/`. Put all the Jekyll text in the `src/` directory. Add the `generated/` directory as a Django template location. When Jekyll stuff gets changed, run the command

`jekyll build --source src/ --destination generated/`

Anyway... Just an idea. I didn't do it in this commit because refactoring all the current HTML to Markdown seemed like it would take a long time. But anyway here's the command I used for this:

```bash
grep -rl 'https://www.continuum.io/content/tj-alumbaugh' . | xargs sed -i "" 's/https:\/\/www\.continuum\.io\/content\/tj\-alumbaugh/https:\/\/github.com\/talumbau/g'
```