### PR TITLE
Resolve edit-parameter page backwards compatibility bugs

### DIFF
--- a/webapp/apps/taxbrain/behaviors.py
+++ b/webapp/apps/taxbrain/behaviors.py
@@ -73,7 +73,10 @@ class Fieldable(models.Model):
             for field in self._meta.fields:
                 if (getattr(self, field.attname, None) and
                     field.name not in nonparam_fields):
-                    self.raw_input_fields[field.name] = getattr(self, field.attname)
+                    raw_val = getattr(self, field.attname)
+                    if field.name.endswith("cpi") and isinstance(raw_val, bool):
+                        raw_val = str(raw_val)
+                    self.raw_input_fields[field.name] = raw_val
 
         param_formatters.amt_fixup(self.raw_input_fields)
         input_fields, failed_lookups = param_formatters.parse_fields(

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -6,6 +6,8 @@ from pyparsing import ParseException
 import six
 import json
 
+from ..constants import START_YEAR
+
 from .models import TaxSaveInputs
 from .helpers import (TaxCalcField, TaxCalcParam, default_policy, is_number,
                       int_to_nth, is_string, string_to_float_array, check_wildcards,
@@ -164,7 +166,8 @@ class TaxBrainForm(PolicyBrainForm, ModelForm):
                         k
                     )
                     self._meta.widgets[k].attrs["placeholder"] = django_val
-
+        if first_year is None:
+            first_year = START_YEAR
         self._first_year = int(first_year)
         self._default_params = default_policy(self._first_year)
 

--- a/webapp/apps/taxbrain/tests/test_models.py
+++ b/webapp/apps/taxbrain/tests/test_models.py
@@ -50,12 +50,14 @@ class TaxBrainStaticFieldsTest(TaxBrainFieldsTest, TestCase):
             ID_AmountCap_Switch_0='True',
             FICA_ss_trt='0.10',
             STD_cpi='True',
+            SS_Earnings_c_cpi=True,
             first_year=start_year
         )
         tsi.save()
         tsi.set_fields()
         assert tsi.input_fields['_FICA_ss_trt'] == [0.10]
         assert tsi.input_fields['_STD_cpi'] == True
+        assert tsi.input_fields['_SS_Earnings_c_cpi'] == True
         assert tsi.input_fields['_ID_AmountCap_Switch_medical'] == [True]
 
     def test_deprecated_fields(self):

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -577,11 +577,11 @@ def edit_personal_results(request, pk):
 
     init_context = {
         'form': form_personal_exemp,
-        'params': nested_form_parameters(int(start_year)),
+        'params': nested_form_parameters(int(form_personal_exemp._first_year)),
         'taxcalc_version': taxcalc_vers_disp,
         'webapp_version': webapp_vers_disp,
         'start_years': START_YEARS,
-        'start_year': str(start_year),
+        'start_year': str(form_personal_exemp._first_year),
         'is_edit_page': True,
         'has_errors': False
     }


### PR DESCRIPTION
In some last minute testing, I pointed my local app to a back up of the production database and uncovered two backwards compatibility bugs that sprung up when you visited the edit parameter pages for older runs:

- CPI parameters were stored as boolean values not as strings.
- For really old runs, the start year value is null.