### PR TITLE
Remove errors for un-displayed parameters and save input data for warning/error message page

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,7 +13,7 @@ Release 1.4.2 on 2018-02-28
 - None
 
 **Bug Fixes**
-- [#827](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/827) - Catch case where error is added for widow params - Hank Doupe
+- [#827](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/827) - Remove errors for un-displayed parameters and save input data for warning/error message page - Hank Doupe
 
 
 Release 1.4.1 on 2018-02-27

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,18 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
+Release 1.4.2 on 2018-02-28
+----------------------------
+**Major Changes**
+- None
+
+**Minor Changes**
+- None
+
+**Bug Fixes**
+- [#827](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/827) - Catch case where error is added for widow params - Hank Doupe
+
+
 Release 1.4.1 on 2018-02-27
 ----------------------------
 **Major Changes**

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,10 +1,10 @@
-gevent
-pillow
-pyparsing
-bokeh=0.12.7
 nomkl
 taxcalc==0.15.2
 btax==0.2.2
 ogusa==0.5.8
 numba>=0.33.0
 pandas>=0.22.0
+gevent
+pillow
+pyparsing
+bokeh=0.12.7

--- a/webapp/apps/dynamic/models.py
+++ b/webapp/apps/dynamic/models.py
@@ -126,6 +126,7 @@ class DynamicBehaviorSaveInputs(Fieldable, Resultable, models.Model):
             2. Map TB names to TC names
             3. Do more specific type checking--in particular, check if
                field is the type that Tax-Calculator expects from this param
+            4. Remove errors on undisplayed parameters
         """
         Fieldable.set_fields(self, taxcalc.Behavior,
                              nonparam_fields=self.NONPARAM_FIELDS)

--- a/webapp/apps/dynamic/models.py
+++ b/webapp/apps/dynamic/models.py
@@ -126,7 +126,6 @@ class DynamicBehaviorSaveInputs(Fieldable, Resultable, models.Model):
             2. Map TB names to TC names
             3. Do more specific type checking--in particular, check if
                field is the type that Tax-Calculator expects from this param
-            4. Remove errors on undisplayed parameters
         """
         Fieldable.set_fields(self, taxcalc.Behavior,
                              nonparam_fields=self.NONPARAM_FIELDS)

--- a/webapp/apps/taxbrain/behaviors.py
+++ b/webapp/apps/taxbrain/behaviors.py
@@ -97,6 +97,14 @@ class Fieldable(models.Model):
 
         self.input_fields = input_fields
 
+    def pop_extra_errors(self, errors_warnings):
+        for action in ['warnings', 'errors']:
+            params = list(errors_warnings[action].keys())
+            for param in params:
+                if param not in self.raw_input_fields:
+                    errors_warnings[action].pop(param)
+
+
     def get_model_specs(self):
         """
         Stub to remind that this part of the API is needed

--- a/webapp/apps/taxbrain/behaviors.py
+++ b/webapp/apps/taxbrain/behaviors.py
@@ -98,6 +98,9 @@ class Fieldable(models.Model):
         self.input_fields = input_fields
 
     def pop_extra_errors(self, errors_warnings):
+        """
+        Removes errors on extra parameters
+        """
         for action in ['warnings', 'errors']:
             params = list(errors_warnings[action].keys())
             for param in params:

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -187,6 +187,10 @@ class TaxBrainForm(PolicyBrainForm, ModelForm):
         # https://www.pydanny.com/overloading-form-fields.html
         self.fields.update(self.Meta.update_fields)
 
+        print('SS_Earnings_c_cpi field', self.fields['SS_Earnings_c_cpi'].__dict__)
+        print('SS_Earnings_c_cpi widget', self.fields['SS_Earnings_c_cpi'].widget.__dict__)
+        print('SS_Earnings_c_cpi meta widget', self._meta.widgets['SS_Earnings_c_cpi'].__dict__)
+
     def clean(self):
         """
         " This method should be used to provide custom model validation, and to

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -770,6 +770,7 @@ class TaxSaveInputs(Fieldable, Resultable, models.Model):
             2. Map TB names to TC names
             3. Do more specific type checking--in particular, check if
                field is the type that Tax-Calculator expects from this param
+            4. Remove errors on undisplayed parameters
         """
         Fieldable.set_fields(self, taxcalc.Policy,
                              nonparam_fields=self.NONPARAM_FIELDS)

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -780,10 +780,14 @@ class TaxSaveInputs(Fieldable, Resultable, models.Model):
 
         returns: reform_dict, assumptions_dict, errors_warnings
         """
-        return param_formatters.get_reform_from_gui(
+        (reform_dict, assumptions_dict, reform_text, assumptions_text,
+            errors_warnings) = param_formatters.get_reform_from_gui(
             self.start_year,
             taxbrain_fields=self.input_fields,
         )
+        Fieldable.pop_extra_errors(self, errors_warnings)
+        return (reform_dict, assumptions_dict, reform_text, assumptions_text,
+            errors_warnings)
 
     @property
     def start_year(self):

--- a/webapp/apps/taxbrain/param_formatters.py
+++ b/webapp/apps/taxbrain/param_formatters.py
@@ -68,9 +68,7 @@ def parse_value(value, meta_param):
         parsed = ast.literal_eval(prepped)
     except ValueError:
         return parsed
-    print('parsed', parsed)
-    print('integer_value', integer_value)
-    print('boolean_value', boolean_value)
+
     # Use information given to us by upstream specs to convert this value
     # into desired type or let upstream package throw error
     if boolean_value:
@@ -145,7 +143,6 @@ def parse_fields(param_dict, default_params):
             for item in v.split(","):
                  values.append(parse_value(item, meta_param))
         parsed[meta_param.param_name] = values
-        print(meta_param.param_name, values, v, meta_param.param_meta['integer_value'])
 
     return parsed, failed_lookups
 

--- a/webapp/apps/taxbrain/param_formatters.py
+++ b/webapp/apps/taxbrain/param_formatters.py
@@ -68,7 +68,9 @@ def parse_value(value, meta_param):
         parsed = ast.literal_eval(prepped)
     except ValueError:
         return parsed
-
+    print('parsed', parsed)
+    print('integer_value', integer_value)
+    print('boolean_value', boolean_value)
     # Use information given to us by upstream specs to convert this value
     # into desired type or let upstream package throw error
     if boolean_value:
@@ -94,7 +96,7 @@ def parse_value(value, meta_param):
             # upstream package will handle the error
             return parsed
     else: # parsed is type float
-        return parsed
+        return float(parsed)
 
 def parse_fields(param_dict, default_params):
     """
@@ -143,6 +145,7 @@ def parse_fields(param_dict, default_params):
             for item in v.split(","):
                  values.append(parse_value(item, meta_param))
         parsed[meta_param.param_name] = values
+        print(meta_param.param_name, values, v, meta_param.param_meta['integer_value'])
 
     return parsed, failed_lookups
 

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -387,7 +387,17 @@ class TaxBrainViewsTests(TestCase):
 
         check_posted_params(result['tb_dropq_compute'], truth_mods, START_YEAR)
 
+    def test_taxbrain_warning_on_widow_param(self):
+        """
+        Set upper threshold for income tax bracket 1 to *, *, 38000
+        income tax bracket 2 will inflate above 38000 so should give
+        no error
+        """
+        data = get_post_data(START_YEAR, _ID_BenefitSurtax_Switches=False)
+        data[u'STD_3'] = ['10000']
+        response = self.client.post('/taxbrain/', data)
 
+        assert response.status_code == 200
 
     def test_taxbrain_wildcard_in_validation_params_gives_error(self):
         """

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -389,9 +389,7 @@ class TaxBrainViewsTests(TestCase):
 
     def test_taxbrain_warning_on_widow_param(self):
         """
-        Set upper threshold for income tax bracket 1 to *, *, 38000
-        income tax bracket 2 will inflate above 38000 so should give
-        no error
+        Test case where error is added on undisplayed parameter
         """
         data = get_post_data(START_YEAR, _ID_BenefitSurtax_Switches=False)
         data[u'STD_3'] = ['10000']

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -439,6 +439,8 @@ def personal_results(request):
     has_errors = False
     use_puf_not_cps = True
     if request.method=='POST':
+        print('method=POST get', request.GET)
+        print('method=POST post', request.POST)
         obj, _, has_errors, _ = process_reform(request)
 
         # case where validation failed in forms.TaxBrainForm
@@ -456,8 +458,8 @@ def personal_results(request):
 
     else:
         # Probably a GET request, load a default form
-        print('get get', request.GET)
-        print('get post', request.POST)
+        print('method=GET get', request.GET)
+        print('method=GET post', request.POST)
         params = parse_qs(urlparse(request.build_absolute_uri()).query)
         if 'start_year' in params and params['start_year'][0] in START_YEARS:
             start_year = params['start_year'][0]

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -266,7 +266,7 @@ def submit_reform(request, user=None, json_reform_id=None):
         if personal_inputs is not None:
             # ensure that parameters causing the warnings are shown on page
             # with warnings/errors
-            personal_inputs.__init__(
+            personal_inputs = TaxBrainForm(
                 start_year,
                 initial=json.loads(personal_inputs.data['raw_input_fields'])
             )

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -264,6 +264,12 @@ def submit_reform(request, user=None, json_reform_id=None):
         taxcalc_errors = True if errors_warnings['errors'] else False
         taxcalc_warnings = True if errors_warnings['warnings'] else False
         if personal_inputs is not None:
+            # ensure that parameters causing the warnings are shown on page
+            # with warnings/errors
+            personal_inputs.__init__(
+                start_year,
+                initial=json.loads(personal_inputs.data['raw_input_fields'])
+            )
             # TODO: parse warnings for file_input
             # only handle GUI errors for now
             if ((taxcalc_errors or taxcalc_warnings)
@@ -447,7 +453,6 @@ def personal_results(request):
         else:
             personal_inputs = obj
             start_year = personal_inputs._first_year
-
 
     else:
         # Probably a GET request, load a default form

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -100,7 +100,8 @@ def test_meta_param():
 )
 def test_parse_values(name, value, exp, default_params_Policy):
     meta_param = get_default_policy_param(name, default_params_Policy)
-    assert parse_value(value, meta_param) == exp
+    act = parse_value(value, meta_param)
+    assert act == exp and type(act) == type(exp)
 
 # Test meta_param construction and attribute access
 def test_parse_fields(default_params_Policy):

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -49,7 +49,7 @@ TEMPLATES = [
 ]
 
 
-WEBAPP_VERSION = "1.4.1"
+WEBAPP_VERSION = "1.4.2"
 
 # Application definition
 


### PR DESCRIPTION
Specifying a parameter for the standard deduction caused a warning on the widow parameter. This PR removes errors that are not allowed on un-displayed parameters.

<img width="749" alt="screen shot 2018-02-28 at 10 51 48 am" src="https://user-images.githubusercontent.com/9206065/36797277-8db3bfba-1c75-11e8-81a6-7168c617a150.png">