### PR TITLE
Generate new form data for each page load

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
-Release 1.4.2 on 2018-02-28
+Release 1.4.2 on 2018-03-01
 ----------------------------
 **Major Changes**
 - None

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,7 @@ Release 1.4.2 on 2018-02-28
 
 **Bug Fixes**
 - [#827](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/827) - Remove errors for un-displayed parameters and save input data for warning/error message page - Hank Doupe
+- [#829](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/829) - Generate new form data for each page load - Hank Doupe
 
 
 Release 1.4.1 on 2018-02-27

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -182,7 +182,6 @@ class PolicyBrainForm:
                         ("Operator '<' can only be used "
                          "at the beginning")
                     )
-
             else:
                 assert isinstance(value, bool) or len(value) == 0
 
@@ -207,6 +206,12 @@ class TaxBrainForm(PolicyBrainForm, ModelForm):
         # https://github.com/django/django/blob/1.9/django/forms/models.py#L284-L285
         if "instance" in kwargs:
             kwargs["initial"] = kwargs["instance"].raw_input_fields
+
+        # Update CPI flags if either
+        # 1. initial is specified in `kwargs` (reform has warning/error msgs)
+        # 2. if `instance` is specified and `initial` is added above
+        #    (edit parameters page)
+        if kwargs.get("initial", False):
             for k, v in kwargs["initial"].iteritems():
                 if k.endswith("cpi") and v:
                     # raw data is stored as choices 1, 2, 3 with the following

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -192,6 +192,8 @@ TAXCALC_DEFAULTS_2016 = default_policy(2016)
 class TaxBrainForm(PolicyBrainForm, ModelForm):
 
     def __init__(self, first_year, *args, **kwargs):
+        # reset form data; form data from the `Meta` class is not updated each
+        # time a new `TaxBrainForm` instance is created
         self.set_form_data()
         # move parameter fields into `raw_fields` JSON object
         args = self.add_fields(args)


### PR DESCRIPTION
This PR refactors the TaxBrain form logic so that the page form data is re-generated each time a page is loaded. In order to save user input data as a JSON object instead of columns (see #822), we need to dynamically add fields to the `ModelForm` subclass. We must do this because the `ModelForm` class expects there to be a mapping from the database fields to the form fields. But, what we have is a mapping from form fields to items in a JSON object which is stored in the database more or less as a blob of data. Thus, the form fields were dynamically created from the keys in the blob of data. This was done by directly modifying the `fields` attribute of an instance of (subclass of?) `django.ModelForms`. 

The previous logic created all of the form data once--on start up--in an inner class `Meta`. Then, if the user changed the start year, all of the data was updated according to the Tax-Calculator `current_law_policy.json` document. After implementing PR #822, we were updating form data in `self.fields` (thinking of `self` is in a `TaxBrainForms` instance) and in the `self._meta.widgets` object which I think was created from the `Meta` class. We were essentially updating two different objects with the same data. This had some strange side effects that I missed while developing and testing locally via REPL type methods (i.e. change some code, print some output, load a page or two, change some more code, etc.).

This method of development involved saving and reloading the modules pretty regularly. Once I got the desired behavior, I merged my changes, ran some tests on the test app, pushed to production, ran a few quick tests immediately after, and was quite surprised when I checked this morning and saw that all of the CPI flags were off. After much head scratching over the fact that the production app had a bug while the test app and my local instance did not, I realized that the test app and my local instance had the same bug. After much more head scratching, I realized that everything worked just fine on the test app immediately after I deployed and locally immediately after I made a change (i.e. triggered Django to save and reload all of the modules and classes). I came to the conclusion that the same data was being updated and manipulated, and it was not being reloaded as I assumed. Apparently, this is how inner classes like `Meta` work.

The changes in this PR do two things:
1. Reload the form fields and widgets each time a new form is created. This will probably increase the time required to load the page, but it fixes our CPI parameter bug. I think the load-time issue can be improved in the future.
2. Only operate on `self.widgets` and `self.fields`. I think that one of the problems was operating on the data that is either stored in different places or is the same but is accessed differently. That is accessing `self.fields` and `self._meta.widgets` separately.