### PR TITLE
Add column ID's back to PolicyBrain

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,17 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
+Release 1.4.4 on 2018-03-08
+----------------------------
+**Major Changes**
+- None
+
+**Minor Changes**
+- None
+
+**Bug Fixes**
+- [#840](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/840) - Add column ID's back to PolicyBrain - Hank Doupe
+
 Release 1.4.3 on 2018-03-07
 ----------------------------
 **Major Changes**

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -158,14 +158,14 @@ class PolicyBrainForm:
                     checkbox = forms.CheckboxInput(attrs=attrs, check_test=bool_like)
                     widgets[field.id] = checkbox
                     update_fields[field.id] = forms.BooleanField(
-                        label='',
+                        label=field.label,
                         widget=widgets[field.id],
                         required=False
                     )
                 else:
                     widgets[field.id] = forms.TextInput(attrs=attrs)
                     update_fields[field.id] = forms.fields.CharField(
-                        label='',
+                        label=field.label,
                         widget=widgets[field.id],
                         required=False
                     )
@@ -184,7 +184,7 @@ class PolicyBrainForm:
 
                 widgets[field.id] = forms.NullBooleanSelect(attrs=attrs)
                 update_fields[field.id] = forms.NullBooleanField(
-                    label='',
+                    label=field.label,
                     widget=widgets[field.id],
                     required=False
                 )

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -49,7 +49,7 @@ TEMPLATES = [
 ]
 
 
-WEBAPP_VERSION = "1.4.3"
+WEBAPP_VERSION = "1.4.4"
 
 # Application definition
 


### PR DESCRIPTION
The column labels were removed in PR #822. This PR adds them back:

![screen shot 2018-03-08 at 10 14 54 am](https://user-images.githubusercontent.com/9206065/37158525-92d655b2-22b9-11e8-9ce9-d80b80d35d39.png)
