### PR TITLE
Gray out fields based on data-source selection

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,17 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
+Release 1.4.5 on 2018-03-13
+----------------------------
+**Major Changes**
+- None
+
+**Minor Changes**
+- [#842](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/842/)[Gray out fields based on data-source selection] - Hank Doupe and Sean Wang
+
+**Bug Fixes**
+- None
+
 Release 1.4.4 on 2018-03-08
 ----------------------------
 **Major Changes**

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
-Release 1.4.5 on 2018-03-13
+Release 1.5.0 on 2018-03-13
 ----------------------------
 **Major Changes**
 - None

--- a/deploy/taxbrain_server/celery_tasks.py
+++ b/deploy/taxbrain_server/celery_tasks.py
@@ -80,16 +80,17 @@ def dropq_task(year_n, user_mods, first_budget_year, use_puf_not_cps=True, use_f
 
 
 @celery_app.task
-def dropq_task_async(year, user_mods, first_budget_year):
-    print('dropq_task_async', year, user_mods, first_budget_year)
+def dropq_task_async(year, user_mods, first_budget_year, use_puf_not_cps=True):
+    print('dropq_task_async', year, user_mods, first_budget_year, use_puf_not_cps)
     return dropq_task(year, user_mods, first_budget_year,
-                      use_puf_not_cps=True, use_full_sample=True)
+                      use_puf_not_cps=use_puf_not_cps, use_full_sample=True)
 
 
 @celery_app.task
-def dropq_task_small_async(year, user_mods, first_budget_year):
+def dropq_task_small_async(year, user_mods, first_budget_year, use_puf_not_cps=True):
+    print('dropq_task_small_async', year, user_mods, first_budget_year, use_puf_not_cps)
     return dropq_task(year, user_mods, first_budget_year,
-                      use_puf_not_cps=True, use_full_sample=False)
+                      use_puf_not_cps=use_puf_not_cps, use_full_sample=False)
 
 
 @celery_app.task

--- a/deploy/taxbrain_server/flask_server.py
+++ b/deploy/taxbrain_server/flask_server.py
@@ -66,15 +66,23 @@ def dropq_endpoint(dropq_task):
         year_n = request.form['year']
         user_mods = json.loads(request.form['user_mods'])
         first_budget_year = None if 'first_budget_year' not in request.form else request.form['first_budget_year']
+        use_puf_not_cps = None if 'use_puf_not_cps' not in request.form else request.form['use_puf_not_cps']
     else:
         year_n = request.args.get('year', '')
         first_budget_year = None
 
     year_n = int(year_n)
+    # use_puf_not_cps passed as string. If for some reason it is not supplied
+    # we default to True i.e. using the PUF file
+    if use_puf_not_cps in ('True', 'true') or use_puf_not_cps is None:
+        use_puf_not_cps = True
+    else:
+        use_puf_not_cps = False
     print("year_n", year_n)
     print("user_mods", user_mods)
     print("first_budget_year", first_budget_year)
-    raw_results = dropq_task.delay(year_n, user_mods, first_budget_year)
+    print("use_puf_not_cps", use_puf_not_cps)
+    raw_results = dropq_task.delay(year_n, user_mods, first_budget_year, use_puf_not_cps)
     RUNNING_JOBS[raw_results.id] = raw_results
     length = client.llen(queue_name) + 1
     results = {'job_id':str(raw_results), 'qlength':length}

--- a/deploy/taxbrain_server/flask_server.py
+++ b/deploy/taxbrain_server/flask_server.py
@@ -123,7 +123,20 @@ def elastic_endpoint():
     elast_params = json.loads(request.form['gdp_elasticity'])
     first_budget_year = request.form['first_budget_year']
     print("elast params", elast_params, " user_mods: ", user_mods)
-    raw_results = elasticity_gdp_task_async.delay(year_n, user_mods, first_budget_year, elast_params)
+    use_puf_not_cps = request.form['use_puf_not_cps']
+    # use_puf_not_cps passed as string. If for some reason it is not supplied
+    # we default to True i.e. using the PUF file
+    if use_puf_not_cps in ('True', 'true') or use_puf_not_cps is None:
+        use_puf_not_cps = True
+    else:
+        use_puf_not_cps = False
+    raw_results = elasticity_gdp_task_async.delay(
+        year_n,
+        user_mods,
+        first_budget_year,
+        elast_params,
+        use_puf_not_cps=use_puf_not_cps
+    )
     RUNNING_JOBS[raw_results.id] = raw_results
     length = client.llen(queue_name) + 1
     results = {'job_id': str(raw_results), 'qlength': length}

--- a/webapp/apps/dynamic/forms.py
+++ b/webapp/apps/dynamic/forms.py
@@ -183,7 +183,7 @@ class DynamicElasticityInputsModelForm(ModelForm):
 
     class Meta:
         model = DynamicElasticitySaveInputs
-        exclude = ['creation_date', 'raw_input_fields', 'input_fields']
+        exclude = ['creation_date']
         widgets = {}
         labels = {}
         for param in ELASTICITY_DEFAULT_PARAMS.values():
@@ -436,7 +436,7 @@ class DynamicInputsModelForm(ModelForm):
 
     class Meta:
         model = DynamicSaveInputs
-        exclude = ['creation_date', 'raw_input_fields', 'input_fields']
+        exclude = ['creation_date']
         widgets = {}
         labels = {}
         for param in OGUSA_DEFAULT_PARAMS.values():

--- a/webapp/apps/dynamic/forms.py
+++ b/webapp/apps/dynamic/forms.py
@@ -22,7 +22,7 @@ ELASTICITY_DEFAULT_PARAMS = default_elasticity_parameters(int(START_YEAR))
 
 class DynamicElasticityInputsModelForm(ModelForm):
 
-    def __init__(self, first_year, *args, **kwargs):
+    def __init__(self, first_year, use_puf_not_cps, *args, **kwargs):
         self._first_year = int(first_year)
         self._default_params = default_elasticity_parameters(self._first_year)
         # Defaults are set in the Meta, but we need to swap
@@ -183,7 +183,7 @@ class DynamicElasticityInputsModelForm(ModelForm):
 
     class Meta:
         model = DynamicElasticitySaveInputs
-        exclude = ['creation_date']
+        exclude = ['creation_date', 'raw_input_fields', 'input_fields']
         widgets = {}
         labels = {}
         for param in ELASTICITY_DEFAULT_PARAMS.values():
@@ -217,7 +217,7 @@ class DynamicElasticityInputsModelForm(ModelForm):
 
 class DynamicBehavioralInputsModelForm(PolicyBrainForm, ModelForm):
 
-    def __init__(self, first_year, *args, **kwargs):
+    def __init__(self, first_year, use_puf_not_cps, *args, **kwargs):
         if first_year is None:
             first_year = START_YEAR
         self._first_year = int(first_year)
@@ -275,7 +275,7 @@ class DynamicBehavioralInputsModelForm(PolicyBrainForm, ModelForm):
 
 class DynamicInputsModelForm(ModelForm):
 
-    def __init__(self, first_year, *args, **kwargs):
+    def __init__(self, first_year, use_puf_not_cps, *args, **kwargs):
         self._first_year = int(first_year)
         self._default_params = default_parameters(self._first_year)
         # Defaults are set in the Meta, but we need to swap
@@ -436,7 +436,7 @@ class DynamicInputsModelForm(ModelForm):
 
     class Meta:
         model = DynamicSaveInputs
-        exclude = ['creation_date']
+        exclude = ['creation_date', 'raw_input_fields', 'input_fields']
         widgets = {}
         labels = {}
         for param in OGUSA_DEFAULT_PARAMS.values():

--- a/webapp/apps/dynamic/models.py
+++ b/webapp/apps/dynamic/models.py
@@ -15,14 +15,14 @@ import taxcalc
 
 from ..taxbrain.models import (CommaSeparatedField, SeparatedValuesField,
                                TaxSaveInputs, OutputUrl)
-from ..taxbrain.behaviors import Resultable, Fieldable
+from ..taxbrain.behaviors import Resultable, Fieldable, DataSourceable
 from ..taxbrain import helpers as taxbrain_helpers
 from ..taxbrain import param_formatters
 
 import datetime
 
 
-class DynamicSaveInputs(models.Model):
+class DynamicSaveInputs(DataSourceable, models.Model):
     """
     This model contains all the parameters for the dynamic tax model and the tax
     result.
@@ -43,8 +43,6 @@ class DynamicSaveInputs(models.Model):
 
     # Starting Year of the reform calculation
     first_year = models.IntegerField(default=None, null=True)
-    # data source for model
-    data_source = models.CharField(default="PUF", blank=True, null=True, max_length=20)
     # Result
     tax_result = JSONField(default=None, blank=True, null=True)
     # Creation DateTime
@@ -62,7 +60,8 @@ class DynamicSaveInputs(models.Model):
         )
 
 
-class DynamicBehaviorSaveInputs(Fieldable, Resultable, models.Model):
+class DynamicBehaviorSaveInputs(DataSourceable, Fieldable, Resultable,
+                                models.Model):
     """
     This model contains all the parameters for the dynamic behavioral tax
     model and the tax result.
@@ -87,8 +86,6 @@ class DynamicBehaviorSaveInputs(Fieldable, Resultable, models.Model):
 
     # Starting Year of the reform calculation
     first_year = models.IntegerField(default=None, null=True)
-    # data source for model
-    data_source = models.CharField(default="PUF", blank=True, null=True, max_length=20)
 
     # Result
     tax_result = JSONField(default=None, blank=True, null=True)
@@ -151,7 +148,7 @@ class DynamicBehaviorSaveInputs(Fieldable, Resultable, models.Model):
         )
 
 
-class DynamicElasticitySaveInputs(models.Model):
+class DynamicElasticitySaveInputs(DataSourceable, models.Model):
     """
     This model contains all the parameters for the dynamic elasticity
     wrt GDP dynamic macro model and tax result
@@ -166,8 +163,6 @@ class DynamicElasticitySaveInputs(models.Model):
 
     # Starting Year of the reform calculation
     first_year = models.IntegerField(default=None, null=True)
-    # data source for model
-    data_source = models.CharField(default="PUF", blank=True, null=True, max_length=20)
     # Result
     tax_result = JSONField(default=None, blank=True, null=True)
     # Creation DateTime

--- a/webapp/apps/dynamic/tests/test_behavioral.py
+++ b/webapp/apps/dynamic/tests/test_behavioral.py
@@ -14,7 +14,7 @@ from ...taxbrain.compute import DropqCompute, MockCompute, ElasticMockCompute
 import taxcalc
 from taxcalc import Policy
 
-from .utils import do_behavioral_sim, START_YEAR
+from .utils import do_dynamic_sim, START_YEAR
 from ...test_assets.utils import (check_posted_params, do_micro_sim,
                                   get_post_data, get_file_post_data)
 
@@ -44,26 +44,25 @@ class DynamicBehavioralViewsTests(TestCase):
 
         # Do the partial equilibrium simulation based on the third microsim
         pe_reform = {u'BE_inc': [u'-0.4']}
-        pe_response = do_behavioral_sim(self.client, micro3, pe_reform)
+        pe_response = do_dynamic_sim(self.client, 'behavioral', micro3, pe_reform)
         orig_micro_model_num = micro3.url[-2:-1]
 
         # Now edit this partial equilibrium sim
         # Go to behavioral input page
         behavior_num = pe_response.url[pe_response.url[:-1].rfind('/')+1:-1]
-        dynamic_behavior_edit = '/dynamic/behavioral/edit/{0}?start_year={1}'.format(behavior_num, START_YEAR)
-        #Redirect first
+        dynamic_behavior_edit = '/dynamic/behavioral/edit/{0}/?start_year={1}'.format(behavior_num, START_YEAR)
+        # load page
         response = self.client.get(dynamic_behavior_edit)
-        self.assertEqual(response.status_code, 301)
-        #Now load the page
-        rep2 = self.client.get(response.url)
-        page = rep2.content
+        self.assertEqual(response.status_code, 200)
+        page = response.content
         # Read the page to find the linked microsim. It should be the third
         # microsim above
         idx = page.find('dynamic/behavioral')
         idx_ms_num_start = idx + 19
         idx_ms_num_end = idx_ms_num_start + page[idx_ms_num_start:].find('/')
         microsim_model_num = page[idx_ms_num_start:idx_ms_num_end]
-        assert microsim_model_num == orig_micro_model_num
+        microsim_url = page[idx:idx_ms_num_end]
+        assert 'dynamic/behavioral/{0}'.format(microsim_model_num) == microsim_url
 
     def test_behavioral_reform_with_wildcard(self):
         # Do the microsim
@@ -75,7 +74,7 @@ class DynamicBehavioralViewsTests(TestCase):
 
         # Do the partial equilibrium simulation based on the microsim
         pe_reform = {u'BE_sub': [u'0.25']}
-        pe_response = do_behavioral_sim(self.client, micro1, pe_reform)
+        pe_response = do_dynamic_sim(self.client, 'behavioral', micro1, pe_reform)
         orig_micro_model_num = micro1.url[-2:-1]
         from webapp.apps.dynamic import views
         post = views.dropq_compute.last_posted
@@ -85,6 +84,27 @@ class DynamicBehavioralViewsTests(TestCase):
         assert user_mods["policy"]["2020"][u'_SS_Earnings_c'][0]  == 15000.0
         assert user_mods["behavior"]["2016"]["_BE_sub"][0] == 0.25
 
+    def test_behavioral_reform_cps(self):
+        # Do the microsim
+        start_year = u'2016'
+        data = get_post_data(start_year)
+        data[u'SS_Earnings_c'] = [u'*,*,*,*,15000']
+        data['data_source'] = 'CPS'
+
+        micro1 = do_micro_sim(self.client, data)["response"]
+
+        # Do the partial equilibrium simulation based on the microsim
+        pe_reform = {u'BE_sub': [u'0.25']}
+        pe_response = do_dynamic_sim(self.client, 'behavioral', micro1, pe_reform)
+        orig_micro_model_num = micro1.url[-2:-1]
+        from webapp.apps.dynamic import views
+        post = views.dropq_compute.last_posted
+        # Verify that partial equilibrium job submitted with proper
+        # SS_Earnings_c with wildcards filled in properly
+        user_mods = json.loads(post['user_mods'])
+        assert user_mods["policy"]["2020"][u'_SS_Earnings_c'][0]  == 15000.0
+        assert user_mods["behavior"]["2016"]["_BE_sub"][0] == 0.25
+        assert post['use_puf_not_cps'] == False
 
     def test_behavioral_reform_from_file(self):
         # Do the microsim from file
@@ -94,7 +114,7 @@ class DynamicBehavioralViewsTests(TestCase):
 
         # Do the partial equilibrium simulation based on the microsim
         be_reform = {u'BE_sub': [u'0.25']}
-        be_response = do_behavioral_sim(self.client, micro1, be_reform)
+        be_response = do_dynamic_sim(self.client, 'behavioral', micro1, be_reform)
         orig_micro_model_num = micro1.url[-2:-1]
         from webapp.apps.dynamic import views
         post = views.dropq_compute.last_posted

--- a/webapp/apps/dynamic/tests/test_models.py
+++ b/webapp/apps/dynamic/tests/test_models.py
@@ -27,6 +27,17 @@ class TaxBrainDynamicFieldsTest(TaxBrainFieldsTest, TestCase):
     def test_set_fields(self):
         start_year = 2017
         fields = self.test_coverage_behavioral_gui_fields.copy()
-        fields["first_year"] = start_year
+        fields['first_year'] = start_year
         self.parse_fields(start_year, fields,
                           Form=DynamicBehavioralInputsModelForm)
+
+    def test_data_source_puf(self):
+        start_year = 2017
+        fields = self.test_coverage_behavioral_gui_fields.copy()
+        fields['first_year'] = start_year
+        fields['data_source'] = 'PUF'
+        model = self.parse_fields(start_year, fields,
+                                  Form=DynamicBehavioralInputsModelForm,
+                                  use_puf_not_cps=True)
+
+        assert model.use_puf_not_cps

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -231,6 +231,7 @@ def dynamic_behavioral(request, pk):
                 )
                 json_reform.save()
                 taxbrain_model.json_text = json_reform
+                taxbrain_model.save()
             else:
                 reform_dict = json.loads(taxbrain_model.json_text.reform_text)
 

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -342,7 +342,18 @@ def dynamic_elasticities(request, pk):
             model.data_source = taxbrain_model.data_source
             # necessary for simulations before PR 641
             if not taxbrain_model.json_text:
-                raise NotImplementedError("Backwards compatibility has not been implemented yet")
+                taxbrain_model.set_fields()
+                (reform_dict, assumptions_dict, reform_text, assumptions_text,
+                    errors_warnings) = taxbrain_model.get_model_specs()
+                json_reform = JSONReformTaxCalculator(
+                    reform_text=json.dumps(reform_dict),
+                    assumption_text=json.dumps(assumptions_dict),
+                    raw_reform_text=reform_text,
+                    raw_assumption_text=assumptions_text
+                )
+                json_reform.save()
+                taxbrain_model.json_text = json_reform
+                taxbrain_model.save()
             else:
                 reform_dict = json.loads(taxbrain_model.json_text.reform_text)
             # empty assumptions dictionary

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -428,6 +428,7 @@ def edit_dynamic_behavioral(request, pk):
 
     model = DynamicBehaviorSaveInputs.objects.get(pk=url.model_pk)
     start_year = model.first_year
+    model.set_fields()
     #Get the user-input from the model in a way we can render
     ser_model = serializers.serialize('json', [model])
     user_inputs = json.loads(ser_model)

--- a/webapp/apps/taxbrain/behaviors.py
+++ b/webapp/apps/taxbrain/behaviors.py
@@ -113,3 +113,23 @@ class Fieldable(models.Model):
         Stub to remind that this part of the API is needed
         """
         raise NotImplementedError()
+
+
+class DataSourceable(models.Model):
+    """
+    Mix-in for providing data_source field and methods that access it
+    """
+
+    class Meta:
+        abstract = True
+
+    # data source for model
+    data_source = models.CharField(default="PUF", blank=True, null=True, max_length=20)
+
+    @property
+    def use_puf_not_cps(self):
+        # which file to use, front-end not yet implemented
+        if self.data_source == 'PUF':
+            return True
+        else:
+            return False

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -89,7 +89,7 @@ class PolicyBrainForm:
         for k, v in args_data.items():
             if k not in INPUTS_META:
                 raw_fields[k] = v
-            elif k is 'first_year':
+            elif k in ('first_year', 'data_source'):
                 parsed_data[k] = v
             else:
                 pass

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -718,6 +718,9 @@ class TaxCalcParam(object):
                 (attributes["compatible_data"]["cps"] and not use_puf_not_cps) or
                 (attributes["compatible_data"]["puf"] and use_puf_not_cps)
             )
+        else:
+            # if compatible_data is not specified do not gray out
+            self.gray_out = False
 
         # Pretend the start year is 2015 (instead of 2013),
         # until values for that year are provided by taxcalc
@@ -882,7 +885,7 @@ def default_behavior(first_budget_year):
 
 
 # Create a list of default policy
-def default_policy(first_budget_year):
+def default_policy(first_budget_year, use_puf_not_cps=True):
 
     TAXCALC_DEFAULT_PARAMS_JSON = default_taxcalc_data(taxcalc.policy.Policy,
                                                        metadata=True,
@@ -890,7 +893,8 @@ def default_policy(first_budget_year):
 
     default_taxcalc_params = {}
     for k,v in TAXCALC_DEFAULT_PARAMS_JSON.iteritems():
-        param = TaxCalcParam(k,v, first_budget_year)
+        param = TaxCalcParam(k,v, first_budget_year,
+                             use_puf_not_cps=use_puf_not_cps)
         default_taxcalc_params[param.nice_id] = param
 
     TAXCALC_DEFAULT_PARAMS = default_taxcalc_params

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -200,10 +200,11 @@ TAXCALC_HIDDEN_FIELDS = [
 ]
 
 INPUTS_META = (u'has_errors', u'csrfmiddlewaretoken', u'start_year',
-          u'full_calc', u'quick_calc', 'first_year', '_state',
-          'creation_date', 'id', 'job_ids', 'jobs_not_ready',
-          'json_text_id', 'tax_result', 'reform_style',
-          '_micro_sim_cache', 'micro_sim_id', 'raw_fields',)
+               u'full_calc', u'quick_calc', 'first_year', '_state',
+               'creation_date', 'id', 'job_ids', 'jobs_not_ready',
+               'json_text_id', 'tax_result', 'reform_style',
+               '_micro_sim_cache', 'micro_sim_id', 'raw_fields',
+               'data_source', )
 
 #
 # Display TaxCalc result data

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -17,7 +17,7 @@ import taxcalc
 import helpers
 import param_formatters
 
-from behaviors import Resultable, Fieldable
+from behaviors import Resultable, Fieldable, DataSourceable
 
 
 # digit or true/false (case insensitive)
@@ -86,7 +86,7 @@ class ErrorMessageTaxCalculator(models.Model):
     text = models.CharField(blank=True, null=False, max_length=4000)
 
 
-class TaxSaveInputs(Fieldable, Resultable, models.Model):
+class TaxSaveInputs(DataSourceable, Fieldable, Resultable, models.Model):
     """
     This model contains all the parameters for the tax model and the tax
     result.
@@ -706,9 +706,6 @@ class TaxSaveInputs(Fieldable, Resultable, models.Model):
     # Starting Year of the reform calculation
     first_year = models.IntegerField(default=None, null=True)
 
-    # data source for model
-    data_source = models.CharField(default="PUF", blank=True, null=True, max_length=20)
-    
     # Record whether or not this was a quick calculation on a sample of data
     quick_calc = models.BooleanField(default=False)
 

--- a/webapp/apps/taxbrain/tests/test_models.py
+++ b/webapp/apps/taxbrain/tests/test_models.py
@@ -84,3 +84,23 @@ class TaxBrainStaticFieldsTest(TaxBrainFieldsTest, TestCase):
         assert tsi.raw_input_fields['yet_another_deprecated_param'] == '1001'
         assert 'deprecated_param' not in tsi.input_fields
         assert 'yet_another_deprecated_param' not in tsi.input_fields
+
+    def test_data_source_puf(self):
+        start_year = 2017
+        fields = self.test_coverage_gui_fields.copy()
+        fields['first_year'] = start_year
+        fields['data_source'] = 'PUF'
+        model = self.parse_fields(start_year, fields,
+                                  use_puf_not_cps=True)
+
+        assert model.use_puf_not_cps
+
+    def test_data_source_cps(self):
+        start_year = 2017
+        fields = self.test_coverage_gui_fields.copy()
+        fields['first_year'] = start_year
+        fields['data_source'] = 'CPS'
+        model = self.parse_fields(start_year, fields,
+                                  use_puf_not_cps=False)
+
+        assert not model.use_puf_not_cps

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -227,7 +227,7 @@ def submit_reform(request, user=None, json_reform_id=None):
             (reform_dict, assumptions_dict, reform_text, assumptions_text,
                 errors_warnings) = get_reform_from_file(request_files)
         else:
-            personal_inputs = TaxBrainForm(start_year, fields)
+            personal_inputs = TaxBrainForm(start_year, use_puf_not_cps, fields)
             # If an attempt is made to post data we don't accept
             # raise a 400
             if personal_inputs.non_field_errors():
@@ -271,6 +271,7 @@ def submit_reform(request, user=None, json_reform_id=None):
             # with warnings/errors
             personal_inputs = TaxBrainForm(
                 start_year,
+                use_puf_not_cps,
                 initial=json.loads(personal_inputs.data['raw_input_fields'])
             )
             # TODO: parse warnings for file_input
@@ -476,7 +477,8 @@ def personal_results(request):
             else:
                 use_puf_not_cps = False
 
-        personal_inputs = TaxBrainForm(first_year=start_year)
+        personal_inputs = TaxBrainForm(first_year=start_year,
+                                       use_puf_not_cps=use_puf_not_cps)
 
     if use_puf_not_cps:
         data_source = 'PUF'

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -616,7 +616,9 @@ def edit_personal_results(request, pk):
         'start_years': START_YEARS,
         'start_year': str(form_personal_exemp._first_year),
         'is_edit_page': True,
-        'has_errors': False
+        'has_errors': False,
+        'data_sources': DATA_SOURCES,
+        'data_source': model.data_source
     }
 
     return render(request, 'taxbrain/input_form.html', init_context)

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -549,7 +549,8 @@ def submit_micro(request, pk):
     data = {'user_mods': json.dumps(user_mods),
             'first_budget_year': int(start_year),
             'start_budget_year': 0,
-            'num_budget_years': NUM_BUDGET_YEARS}
+            'num_budget_years': NUM_BUDGET_YEARS,
+            'use_puf_not_cps': model.use_puf_not_cps}
 
     # start calc job
     submitted_ids, max_q_length = dropq_compute.submit_dropq_calculation(
@@ -594,7 +595,11 @@ def edit_personal_results(request, pk):
 
     msg = ('Field {} has been deprecated. Refer to the Tax-Caclulator '
            'documentation for a sensible replacement.')
-    form_personal_exemp = TaxBrainForm(first_year=start_year, instance=model)
+    form_personal_exemp = TaxBrainForm(
+        first_year=start_year,
+        use_puf_not_cps=model.use_puf_not_cps,
+        instance=model
+    )
     form_personal_exemp.is_valid()
     if model.deprecated_fields is not None:
         for dep in model.deprecated_fields:

--- a/webapp/apps/test_assets/test_models.py
+++ b/webapp/apps/test_assets/test_models.py
@@ -59,10 +59,10 @@ class TaxBrainTableResults(TaxBrainModelsTest):
 class TaxBrainFieldsTest(TaxBrainModelsTest):
 
     def parse_fields(self, start_year, fields, Form=TaxBrainForm,
-                     exp_result=None):
+                     exp_result=None, use_puf_not_cps=True):
         start_year = 2017
         fields = stringify_fields(fields)
-        form = Form(start_year, fields)
+        form = Form(start_year, use_puf_not_cps, fields)
 
         # returns model object but does not save to the database
         model = form.save(commit=False)
@@ -74,3 +74,5 @@ class TaxBrainFieldsTest(TaxBrainModelsTest):
         # get formatted model specifications
         results = model.get_model_specs()
         # do some kind of check here using `exp_result`
+
+        return model

--- a/webapp/apps/test_assets/utils.py
+++ b/webapp/apps/test_assets/utils.py
@@ -73,7 +73,8 @@ def do_micro_sim(client, data, tb_dropq_compute=None, dyn_dropq_compute=None,
             "pk": response.url[idx+1:-1]}
 
 
-def check_posted_params(mock_compute, params_to_check, start_year):
+def check_posted_params(mock_compute, params_to_check, start_year,
+                        use_puf_not_cps=True):
     """
     Make sure posted params match expected results
     user_mods: parameters that are actually passed to taxcalc
@@ -83,6 +84,7 @@ def check_posted_params(mock_compute, params_to_check, start_year):
     last_posted = mock_compute.last_posted
     user_mods = json.loads(last_posted["user_mods"])
     assert last_posted["first_budget_year"] == int(start_year)
+    assert last_posted["use_puf_not_cps"] == use_puf_not_cps
     for year in params_to_check:
         for param in params_to_check[year]:
             act = user_mods["policy"][str(year)][param]
@@ -141,14 +143,15 @@ def get_file_post_data(start_year, reform_text, assumptions_text=None, quick_cal
 def get_taxbrain_model(_fields, first_year=2017,
                        quick_calc=False, taxcalc_vers="0.13.0",
                        webapp_vers="1.2.0", exp_comp_datetime = "2017-10-10",
-                       Form=TaxBrainForm, UrlModel=OutputUrl):
+                       Form=TaxBrainForm, UrlModel=OutputUrl,
+                       use_puf_not_cps=True):
     fields = _fields.copy()
     fields.pop('_state', None)
     fields.pop('creation_date', None)
     fields.pop('id', None)
     fields = stringify_fields(fields)
 
-    personal_inputs = Form(first_year, fields)
+    personal_inputs = Form(first_year, use_puf_not_cps, fields)
     if not personal_inputs.is_valid():
         print(personal_inputs.errors)
     model = personal_inputs.save(commit=False)

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -49,7 +49,7 @@ TEMPLATES = [
 ]
 
 
-WEBAPP_VERSION = "1.4.5"
+WEBAPP_VERSION = "1.5.0"
 
 # Application definition
 

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -49,7 +49,7 @@ TEMPLATES = [
 ]
 
 
-WEBAPP_VERSION = "1.4.4"
+WEBAPP_VERSION = "1.4.5"
 
 # Application definition
 


### PR DESCRIPTION
This PR gray's out fields depending on the data source selection. For example, if you select the data source "CPS", then you get the following display:

![screen shot 2018-03-09 at 1 25 00 pm](https://user-images.githubusercontent.com/9206065/37223057-511f3ce4-239d-11e8-9851-f92549e63c96.png)

Note that these fields cannot be edited.

cc @andersonfrailey @GoFroggyRun 