### PR TITLE
Pass start year to dynamic behavioral

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,7 @@ Release 1.5.0 on 2018-03-13
 - [#842](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/842/) - Gray out fields based on data-source selection - Hank Doupe and Sean Wang
 
 **Bug Fixes**
-- None
+- [#844](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/842/) - Pass start year to dynamic behavioral - Hank Doupe
 
 Release 1.4.4 on 2018-03-08
 ----------------------------

--- a/webapp/apps/dynamic/tests/test_behavioral.py
+++ b/webapp/apps/dynamic/tests/test_behavioral.py
@@ -84,7 +84,7 @@ class DynamicBehavioralViewsTests(TestCase):
         assert user_mods["policy"]["2020"][u'_SS_Earnings_c'][0]  == 15000.0
         assert user_mods["behavior"]["2016"]["_BE_sub"][0] == 0.25
 
-    def test_behavioral_reform_cps(self):
+    def test_behavioral_reform_post_gui(self):
         # Do the microsim
         start_year = u'2016'
         data = get_post_data(start_year)
@@ -95,13 +95,15 @@ class DynamicBehavioralViewsTests(TestCase):
 
         # Do the partial equilibrium simulation based on the microsim
         pe_reform = {u'BE_sub': [u'0.25']}
-        pe_response = do_dynamic_sim(self.client, 'behavioral', micro1, pe_reform)
+        pe_response = do_dynamic_sim(self.client, 'behavioral', micro1,
+                                     pe_reform, start_year=start_year)
         orig_micro_model_num = micro1.url[-2:-1]
         from webapp.apps.dynamic import views
         post = views.dropq_compute.last_posted
         # Verify that partial equilibrium job submitted with proper
         # SS_Earnings_c with wildcards filled in properly
         user_mods = json.loads(post['user_mods'])
+        assert post["first_budget_year"] == int(start_year)
         assert user_mods["policy"]["2020"][u'_SS_Earnings_c'][0]  == 15000.0
         assert user_mods["behavior"]["2016"]["_BE_sub"][0] == 0.25
         assert post['use_puf_not_cps'] == False
@@ -121,4 +123,5 @@ class DynamicBehavioralViewsTests(TestCase):
         # Verify that partial equilibrium job submitted with proper
         # SS_Earnings_c with wildcards filled in properly
         user_mods = json.loads(post["user_mods"])
+        assert post["first_budget_year"] == int(START_YEAR)
         assert user_mods["behavior"][str(START_YEAR)]["_BE_sub"][0] == 0.25

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -189,20 +189,15 @@ def dynamic_behavioral(request, pk):
     """
     start_year = START_YEAR
     if request.method == 'POST':
+        print('method=POST get', request.GET)
+        print('method=POST post', request.POST)
         fields = dict(request.GET)
         fields.update(dict(request.POST))
         fields = {k: v[0] if isinstance(v, list) else v for k, v in fields.items()}
-        start_year = fields.get('start_year', START_YEAR)
+        start_year = fields['start_year']
         # TODO: migrate first_year to start_year to get rid of weird stuff like
         # this
         fields['first_year'] = fields['start_year']
-
-        # Client is attempting to send inputs, validate as form data
-        # save start_year
-        start_year = (request.GET.get('start_year', None) or
-                      request.POST.get('start_year', None))
-        assert start_year is not None
-        fields['first_year'] = start_year
         # use_puf_not_cps set to True by default--doesn't matter for dynamic
         # input page. It is there for API consistency
         dyn_mod_form = DynamicBehavioralInputsModelForm(start_year, True,
@@ -244,7 +239,6 @@ def dynamic_behavioral(request, pk):
                     'start_budget_year': 0,
                     'num_budget_years': NUM_BUDGET_YEARS,
                     'use_puf_not_cps': model.use_puf_not_cps}
-
             submitted_ids, max_q_length = dropq_compute.submit_dropq_calculation(
                 data
             )
@@ -286,6 +280,12 @@ def dynamic_behavioral(request, pk):
             form_personal_exemp = dyn_mod_form
 
     else:
+        # Probably a GET request, load a default form
+        print('method=GET get', request.GET)
+        print('method=GET post', request.POST)
+        params = parse_qs(urlparse(request.build_absolute_uri()).query)
+        if 'start_year' in params and params['start_year'][0] in START_YEARS:
+            start_year = params['start_year'][0]
         # Probably a GET request, load a default form
         form_personal_exemp = DynamicBehavioralInputsModelForm(
             first_year=start_year,


### PR DESCRIPTION
The start year was not correctly retrieved from the request parameter data. This bug was likely introduced in #822 as part of the effort to upgrade to Django 1.9. This PR fixes this issue. 

[EDIT] The issue was that we quit checking for the start year parameter in the `GET` data. You can see that it was [there initially](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/162/files#diff-ad4af3b555fda282262b117143191048R227). However, since the "blame" was not preserved very well, I'm not sure where this was dropped.