### PR TITLE
Adds data source to file input page, refactors reform submission, and improves tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
   - pushd deploy
-  - conda clean --all
+  - conda clean --all -y
   - ./install_taxbrain_server.sh
   - popd
   - source activate aei_dropq

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
   - pushd deploy
+  - conda clean --all
   - ./install_taxbrain_server.sh
   - popd
   - source activate aei_dropq

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
-Release 1.5.0 on 2018-03-13
+Release 1.5.0 on 2018-03-14
 ----------------------------
 **Major Changes**
 - None
@@ -12,6 +12,7 @@ Release 1.5.0 on 2018-03-13
 **Minor Changes**
 - [#835](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/835/) - Add button to allow CPS as input data source - Sean Wang, Anderson Frailey, and Hank Doupe
 - [#842](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/842/) - Gray out fields based on data-source selection - Hank Doupe and Sean Wang
+- [#847](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/847) - Adds data source to file input page, refactors reform submission, and improves tests - Hank Doupe
 
 **Bug Fixes**
 - [#844](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/842/) - Pass start year to dynamic behavioral - Hank Doupe

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ boto
 django-storages
 django-htmlmin
 pyparsing
+dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,3 @@ boto
 django-storages
 django-htmlmin
 pyparsing
-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ boto
 django-storages
 django-htmlmin
 pyparsing
+python-dateutil

--- a/static/js/filetb.js
+++ b/static/js/filetb.js
@@ -78,11 +78,22 @@ $('#id_factor_adjustment, #id_factor_target').focus(function() {
 
 var currentYear = $('#start-year-select').val();
 $('#start-year-select').change(function(e) {
-  $('#current-year-link').attr('href', '/taxbrain/file/?start_year=' + $(this).val());
+  $('#current-year-link').attr('href', '/taxbrain/file/?start_year=' + $(this).val() + '&data_source=' + $('#data-source-select').val());
   $('#current-year-modal').modal('show');
 });
 
 $('#current-year-modal').on('hide.bs.modal', function (e) {
   $('#start-year-select option').removeAttr("selected");
   $('#start-year-select option[value="' + currentYear + '"]').attr("selected", "selected");
+});
+
+var dataSource = $('#data-source-select').val();
+$('#data-source-select').change(function(e) {
+    $('#data-source-link').attr('href', '/taxbrain/file/?start_year=' + $('#start-year-select').val() + '&data_source=' + $(this).val());
+    $('#data-source-modal').modal('show');
+});
+
+$('#data-choice-modal').on('hide.bs.modal', function (e) {
+  $('#data-source option').removeAttr("selected");
+  $('#data-source option[value="' + dataSource + '"]').attr("selected", "selected");
 });

--- a/templates/taxbrain/input_file.html
+++ b/templates/taxbrain/input_file.html
@@ -124,7 +124,7 @@
         </div>
       </section>
     </div>
-    <form class="inputs-form" method="post" action="/taxbrain/file/?start_year={{start_year}}" enctype="multipart/form-data">
+    <form class="inputs-form" method="post" action="/taxbrain/file/?start_year={{start_year}}&data_source={{data_source}}" enctype="multipart/form-data">
       {% csrf_token %}
       <input type="hidden" name="has_errors" value="{{ has_errors }}" />
       <input type="hidden" name="start_year" value="{{ start_year }}" />
@@ -133,13 +133,20 @@
         <div class="row">
           <div class="col-xs-3">
             <div class="inputs-sidebar" data-spy="affix" data-offset-top="435" data-offset-bottom="245">
-              <label class="">Start Year:
-                <select id="start-year-select" class="form-control pull-right">
-                  {% for year in start_years %}
-                    <option value="{{year}}" {% if year == start_year %} selected {% endif %}>{{year}}</option>
-                  {% endfor %}
-                </select>
+                <label class="">Start Year:
+                  <select id="start-year-select" class="form-control pull-right">
+                    {% for year in start_years %}
+                      <option value="{{year}}" {% if year == start_year %} selected {% endif %}>{{year}}</option>
+                    {% endfor %}
+                  </select>
               </label>
+              <label class=""> Data Source:
+                  <select id="data-source-select" class="form-control pull-right">
+                  {% for data in data_sources %}
+                    <option value="{{data}}" {% if data == data_source %} selected {% endif %}>{{data}}</option>
+                  {% endfor %}
+                  </select>
+               </label>
               <ul class="nav sidebar-nav">
                 <li class="get-started"><a href="#get-started">Get Started</a></li>
                 <li><a href="#json-form">Input Form</a></li>
@@ -200,4 +207,22 @@
       </div>
     </div>
   </div>
+  <div class="modal fade" id="data-source-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="myModalLabel">Change Data Source</h4>
+        </div>
+        <div class="modal-body">
+          Warning: This will clear your current inputs.
+        </div>
+        <div class="modal-footer">
+          <a type="button" class="btn btn-default" data-dismiss="modal">Nevermind.</a>
+          <a type="button" class="btn btn-primary" id="data-source-link">OK, go for it.</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
 {% endblock %}

--- a/webapp/apps/taxbrain/forms.py
+++ b/webapp/apps/taxbrain/forms.py
@@ -199,6 +199,8 @@ TAXCALC_DEFAULTS = {
 class TaxBrainForm(PolicyBrainForm, ModelForm):
 
     def __init__(self, first_year, use_puf_not_cps, *args, **kwargs):
+        # the start year and the data source form object for later access.
+        # This should be refactored into `process_model`
         if first_year is None:
             first_year = START_YEAR
         self._first_year = int(first_year)

--- a/webapp/apps/taxbrain/submit_data.py
+++ b/webapp/apps/taxbrain/submit_data.py
@@ -1,0 +1,26 @@
+from collections import namedtuple
+
+PostMeta = namedtuple(
+    'PostMeta',
+    ['request',
+     'personal_inputs',
+     'json_reform',
+     'model',
+     'stop_submission',
+     'has_errors',
+     'errors_warnings',
+     'start_year',
+     'data_source',
+     'do_full_calc',
+     'is_file',
+     'reform_dict',
+     'assumptions_dict',
+     'reform_text',
+     'assumptions_text',
+     'submitted_ids',
+     'max_q_length',
+     'user',
+     'url']
+)
+
+BadPost = namedtuple('BadPost', ['http_response_404', 'has_errors'])

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -68,7 +68,8 @@ class TestTaxBrainViews(object):
         check_posted_params(result['tb_dropq_compute'], truth_mods,
                             str(START_YEAR), use_puf_not_cps=False)
 
-    def test_taxbrain_quick_calc_post(self):
+    @pytest.mark.parametrize('data_source', ['PUF', 'CPS'])
+    def test_taxbrain_quick_calc_post(self, data_source):
         "Test quick calculation post and full post from quick_calc page"
         # switches 0, 4, 6 are False
         data = get_post_data(START_YEAR, quick_calc=True)
@@ -77,6 +78,7 @@ class TestTaxBrainViews(object):
         data[u'ID_BenefitSurtax_Switch_6'] = ['0.0']
         data[u'II_em'] = [u'4333']
         data[u'ID_AmountCap_Switch_0'] = [u'0']
+        data['data_source'] = data_source
         wnc, created = WorkerNodesCounter.objects.get_or_create(singleton_enforce=1)
         current_dropq_worker_offset = wnc.current_offset
 
@@ -96,7 +98,7 @@ class TestTaxBrainViews(object):
                                    "_II_em": [4333.0]}
                       }
         check_posted_params(result['tb_dropq_compute'], truth_mods,
-                            str(START_YEAR))
+                            str(START_YEAR), data_source=data_source)
 
         # reset worker node count without clearing MockCompute session
         result['tb_dropq_compute'].reset_count()
@@ -112,7 +114,7 @@ class TestTaxBrainViews(object):
 
         # Check that data was saved properly
         check_posted_params(result['tb_dropq_compute'], truth_mods,
-                            str(START_YEAR))
+                            str(START_YEAR), data_source=data_source)
 
     def test_taxbrain_quick_calc_post_cps(self):
         """

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -56,7 +56,7 @@ from ..constants import (DISTRIBUTION_TOOLTIP, DIFFERENCE_TOOLTIP,
 from ..formatters import get_version
 from .param_formatters import (get_reform_from_file, get_reform_from_gui,
                                to_json_reform, append_errors_warnings)
-from submit_data import PostMeta, BadPost
+from .submit_data import PostMeta, BadPost
 
 from django.conf import settings
 WEBAPP_VERSION = settings.WEBAPP_VERSION

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -454,7 +454,6 @@ def personal_results(request):
         print('method=POST get', request.GET)
         print('method=POST post', request.POST)
         obj, post_meta = process_reform(request)
-        print(type(obj), post_meta.__dict__)
         # case where validation failed in forms.TaxBrainForm
         # TODO: assert HttpResponse status is 404
         if isinstance(post_meta, BadPost):

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -56,6 +56,7 @@ from ..constants import (DISTRIBUTION_TOOLTIP, DIFFERENCE_TOOLTIP,
 from ..formatters import get_version
 from .param_formatters import (get_reform_from_file, get_reform_from_gui,
                                to_json_reform, append_errors_warnings)
+from submit_data import PostMeta, BadPost
 
 from django.conf import settings
 WEBAPP_VERSION = settings.WEBAPP_VERSION
@@ -94,33 +95,31 @@ def normalize(x):
     ans = [i.split('#') for i in x]
     return ans
 
-def save_model(url, request, model, json_reform, has_errors, start_year,
-               do_full_calc, is_file, reform_dict, assumptions_dict,
-               reform_text, assumptions_text, submitted_ids,
-               max_q_length, user, data_source):
+def save_model(post_meta):
     """
     Save user input data
     returns OutputUrl object
     """
+    model = post_meta.model
     # create model for file_input case
     if model is None:
         model = TaxSaveInputs()
-    model.job_ids = denormalize(submitted_ids)
-    model.json_text = json_reform
-    model.first_year = int(start_year)
-    model.data_source = data_source
-    model.quick_calc = not do_full_calc
+    model.job_ids = denormalize(post_meta.submitted_ids)
+    model.json_text = post_meta.json_reform
+    model.first_year = int(post_meta.start_year)
+    model.data_source = post_meta.data_source
+    model.quick_calc = not post_meta.do_full_calc
     model.save()
 
     # create OutputUrl object
-    if url is None:
+    if post_meta.url is None:
         unique_url = OutputUrl()
     else:
-        unique_url = url
-    if user:
-        unique_url.user = user
-    elif request and request.user.is_authenticated():
-        current_user = User.objects.get(pk=request.user.id)
+        unique_url = post_meta.url
+    if post_meta.user:
+        unique_url.user = post_meta.user
+    elif post_meta.request and post_meta.request.user.is_authenticated():
+        current_user = User.objects.get(pk=post_meta.request.user.id)
         unique_url.user = current_user
 
     if unique_url.taxcalc_vers is None:
@@ -131,7 +130,7 @@ def save_model(url, request, model, json_reform, has_errors, start_year,
     unique_url.unique_inputs = model
     unique_url.model_pk = model.pk
     cur_dt = datetime.datetime.utcnow()
-    future_offset_seconds = ((2 + max_q_length) * JOB_PROC_TIME_IN_SECONDS)
+    future_offset_seconds = ((2 + post_meta.max_q_length) * JOB_PROC_TIME_IN_SECONDS)
     future_offset = datetime.timedelta(seconds=future_offset_seconds)
     expected_completion = cur_dt + future_offset
     unique_url.exp_comp_datetime = expected_completion
@@ -193,10 +192,10 @@ def submit_reform(request, user=None, json_reform_id=None):
             json_reform = JSONReformTaxCalculator.objects.get(id=int(json_reform_id))
         except Exception as e:
             msg = "ID {} is not in JSON reform database".format(json_reform_id)
-            http_response = HttpResponse(msg, status=400)
-            return {'HttpResponse': http_response,
-                    'has_errors': True}
-
+            return BadPost(
+                       http_response_404=HttpResponse(msg, status=400),
+                       has_errors= True
+                   )
         reform_dict = json.loads(json_reform.reform_text)
         assumptions_dict = json.loads(json_reform.assumption_text)
         reform_text = json_reform.raw_reform_text
@@ -233,8 +232,10 @@ def submit_reform(request, user=None, json_reform_id=None):
             # If an attempt is made to post data we don't accept
             # raise a 400
             if personal_inputs.non_field_errors():
-                return {'HttpResponse': HttpResponse("Bad Input!", status=400),
-                        'has_errors': True}
+                return BadPost(
+                           http_response_404=HttpResponse("Bad Input!", status=400),
+                           has_errors= True
+                       )
             is_valid = personal_inputs.is_valid()
             if is_valid:
                 model = personal_inputs.save(commit=False)
@@ -316,23 +317,28 @@ def submit_reform(request, user=None, json_reform_id=None):
                 data
             )
 
-    return {'personal_inputs': personal_inputs,
-            'json_reform': json_reform,
-            'model': model,
-            'stop_submission': stop_submission,
-            'has_errors': any([taxcalc_errors, taxcalc_warnings,
+    return PostMeta(
+               request=request,
+               personal_inputs=personal_inputs,
+               json_reform=json_reform,
+               model=model,
+               stop_submission=stop_submission,
+               has_errors=any([taxcalc_errors, taxcalc_warnings,
                                no_inputs, not is_valid]),
-            'errors_warnings': errors_warnings,
-            'start_year': start_year,
-            'data_source': data_source,
-            'do_full_calc': do_full_calc,
-            'is_file': is_file,
-            'reform_dict': reform_dict,
-            'assumptions_dict': assumptions_dict,
-            'reform_text': reform_text,
-            'assumptions_text': assumptions_text,
-            'submitted_ids': submitted_ids,
-            'max_q_length': max_q_length}
+               errors_warnings=errors_warnings,
+               start_year=start_year,
+               data_source=data_source,
+               do_full_calc=do_full_calc,
+               is_file=is_file,
+               reform_dict=reform_dict,
+               assumptions_dict=assumptions_dict,
+               reform_text=reform_text,
+               assumptions_text=assumptions_text,
+               submitted_ids=submitted_ids,
+               max_q_length=max_q_length,
+               user=user,
+               url=None
+           )
 
 
 def process_reform(request, user=None, **kwargs):
@@ -346,22 +352,16 @@ def process_reform(request, user=None, **kwargs):
             boolean variable indicating whether this reform has errors or not
 
     """
-    args = submit_reform(request, user=user, **kwargs)
-    if 'HttpResponse' in args:
-        return args['HttpResponse'], None, args['has_errors'], None
+    post_meta = submit_reform(request, user=user, **kwargs)
+    if isinstance(post_meta, BadPost):
+        return None, post_meta
 
-    args['request'] = request
-    args['user'] = user
-    args['url'] = None
-    errors_warnings = args.pop("errors_warnings")
-    if args['stop_submission']:
-        return (args['personal_inputs'], args['json_reform'], args['has_errors'],
-                errors_warnings)
+    if post_meta.stop_submission:
+        return None, post_meta#(args['personal_inputs'], args['json_reform'], args['has_errors'],
+                #errors_warnings)
     else:
-        del args['stop_submission']
-        del args['personal_inputs']
-        url = save_model(**args)
-        return url, args['json_reform'], args['has_errors'], errors_warnings
+        url = save_model(post_meta)
+        return url, post_meta
 
 
 def file_input(request):
@@ -394,24 +394,16 @@ def file_input(request):
             errors = ["Please specify a tax-law change before submitting."]
             json_reform = None
         else:
-            (obj, json_reform, has_errors,
-                errors_warnings) = process_reform(
-                request,
-                json_reform_id=form_id
-            )
-            if has_errors and isinstance(obj, HttpResponse):
-                return obj
+            obj, post_meta = process_reform(request, json_reform_id=form_id)
+            if isinstance(post_meta, BadPost):
+                return post_meta.http_response_404
             else:
                 unique_url = obj
 
-            # Case 1: has_errors is True and there are warning/error messages
-            #         --> display errors
-            # Case 2: has_errors is False and there are warning messages
-            #         --> run model (user has already seen warning messages)
-            # Case 3: has_errors is False and there are no warning/error messages
-            #         --> run model
-            if (has_errors and
-               (errors_warnings['warnings'] or errors_warnings['errors'])):
+            if post_meta.stop_submission:
+                errors_warnings = post_meta.errors_warnings
+                json_reform = post_meta.json_reform
+                has_errors = post_meta.has_errors
                 errors.append(OUT_OF_RANGE_ERROR_MSG)
                 append_errors_warnings(
                     errors_warnings,
@@ -457,24 +449,30 @@ def personal_results(request):
     """
     start_year = START_YEAR
     has_errors = False
-    use_puf_not_cps = True
+    data_source = DEFAULT_SOURCE
     if request.method=='POST':
         print('method=POST get', request.GET)
         print('method=POST post', request.POST)
-        obj, _, has_errors, _ = process_reform(request)
-
+        obj, post_meta = process_reform(request)
+        print(type(obj), post_meta.__dict__)
         # case where validation failed in forms.TaxBrainForm
         # TODO: assert HttpResponse status is 404
-        if has_errors and isinstance(obj, HttpResponse):
-            return obj
+        if isinstance(post_meta, BadPost):
+            return post_meta.http_response_404
 
         # No errors--submit to model
-        if not has_errors:
+        if not post_meta.stop_submission:
             return redirect(obj)
         # Errors from taxcalc.tbi.reform_warnings_errors
         else:
             personal_inputs = obj
-            start_year = personal_inputs._first_year
+            start_year = post_meta.start_year
+            data_source = post_meta.data_source
+            if data_source == 'PUF':
+                use_puf_not_cps = True
+            else:
+                use_puf_not_cps = False
+            has_errors = post_meta.has_errors
 
     else:
         # Probably a GET request, load a default form
@@ -484,22 +482,16 @@ def personal_results(request):
         if 'start_year' in params and params['start_year'][0] in START_YEARS:
             start_year = params['start_year'][0]
 
+        # use puf by default
+        use_puf_not_cps = True
         if 'data_source' in params and params['data_source'][0] in DATA_SOURCES:
             data_source = params['data_source'][0]
-            print('we got the data source', data_source, 'now what...')
-            if data_source == 'PUF':
-                use_puf_not_cps = True
-            else:
+            if data_source != 'PUF':
                 use_puf_not_cps = False
 
         personal_inputs = TaxBrainForm(first_year=start_year,
                                        use_puf_not_cps=use_puf_not_cps)
 
-    if use_puf_not_cps:
-        data_source = 'PUF'
-    else:
-        data_source = 'CPS'
-    print(data_source, DATA_SOURCES)
     init_context = {
         'form': personal_inputs,
         'params': nested_form_parameters(int(start_year), use_puf_not_cps),
@@ -573,26 +565,29 @@ def submit_micro(request, pk):
         data
     )
 
-    args = {'url': url,
-            'request': request,
-            'model': model,
-            'json_reform': json_reform,
-            'has_errors': False,
-            'start_year': start_year,
-            'data_source': model.data_source,
-            'do_full_calc': True,
-            'is_file': is_file,
-            'reform_dict': reform_dict,
-            'assumptions_dict': assumptions_dict,
-            'reform_text': (model.json_text.raw_reform_text
+    post_meta = PostMeta(url=url,
+            request=request,
+            model=model,
+            json_reform=json_reform,
+            has_errors=False,
+            start_year=start_year,
+            data_source=model.data_source,
+            do_full_calc=True,
+            is_file=is_file,
+            reform_dict=reform_dict,
+            assumptions_dict=assumptions_dict,
+            reform_text=(model.json_text.raw_reform_text
                             if model.json_text else ""),
-            'assumptions_text': (model.json_text.raw_assumption_text
+            assumptions_text=(model.json_text.raw_assumption_text
                                  if model.json_text else ""),
-            'submitted_ids': submitted_ids,
-            'max_q_length': max_q_length,
-            'user': None}
+            submitted_ids=submitted_ids,
+            max_q_length=max_q_length,
+            user=None,
+            personal_inputs=None,
+            stop_submission=False,
+            errors_warnings=None)
 
-    url = save_model(**args)
+    url = save_model(post_meta)
 
     return redirect(url)
 

--- a/webapp/apps/test_assets/utils.py
+++ b/webapp/apps/test_assets/utils.py
@@ -129,6 +129,7 @@ def get_file_post_data(start_year, reform_text, assumptions_text=None, quick_cal
     data = {u'docfile': tc_file,
             u'has_errors': [u'False'],
             u'start_year': unicode(start_year),
+            'data_source': 'PUF',
             u'quick_calc': quick_calc,
             'csrfmiddlewaretoken':'abc123'}
 

--- a/webapp/apps/test_assets/utils.py
+++ b/webapp/apps/test_assets/utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import ast
+import six
 
 from ..taxbrain.compute import MockCompute
 
@@ -74,7 +75,7 @@ def do_micro_sim(client, data, tb_dropq_compute=None, dyn_dropq_compute=None,
 
 
 def check_posted_params(mock_compute, params_to_check, start_year,
-                        use_puf_not_cps=True):
+                        use_puf_not_cps=True, data_source=None):
     """
     Make sure posted params match expected results
     user_mods: parameters that are actually passed to taxcalc
@@ -84,6 +85,8 @@ def check_posted_params(mock_compute, params_to_check, start_year,
     last_posted = mock_compute.last_posted
     user_mods = json.loads(last_posted["user_mods"])
     assert last_posted["first_budget_year"] == int(start_year)
+    if data_source is not None:
+        use_puf_not_cps = True if data_source == 'PUF' else False
     assert last_posted["use_puf_not_cps"] == use_puf_not_cps
     for year in params_to_check:
         for param in params_to_check[year]:


### PR DESCRIPTION
This PR does three things:

1. Adds the data source to the file input page using the same approach as the GUI input page
2. Refactors the reform submission to the worker nodes so that the post data is stored in a `namedtuple` instead of a dictionary. This replaces a combination of dictionaries and tuples with the class-like `namedtuple`. In my opinion, this enhances the readability of the code. I'm interested in others thoughts on this though.
3. In order to utilize pytest's `parameterize` functionality in class methods, the class has to inherit from `object`. Since many methods needed to be tested with both `data_source` arguments ('PUF' and 'CPS') and there wasn't much benefit from using `django.TestCase`, I made this change. For now, this only applies to the TaxBrain static model views tests. However, future PR's should propagate this change to the other views test classes.