### PR TITLE
[WIP] Add age button to "build table" widget 

### DIFF
--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -358,6 +358,13 @@ $(function() {
                   <li class="active" data-grouping="bin"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.bins %>" href="#">Income Bins</a></li>\
                   <li data-grouping="dec"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.deciles %>" href="#">Income Deciles</a></li>\
                 </ul>\
+                <br>\
+                <br>\
+                <ul id="age" class="nav nav-pills nav-justified">\
+                  <li class="active" data-under65="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.payroll %>" href="#">Under Age 65</a></li>\
+                  <li><h1 class="text-center" style="margin:0">+</h1></li>\
+                  <li class="active" data-65andabove="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.income %>" href="#">Age 65 & Above</a></li>\
+                </ul>\
               </div>\
             </div>'),
 

--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -361,9 +361,9 @@ $(function() {
                 <br>\
                 <br>\
                 <ul id="age" class="nav nav-pills nav-justified">\
-                  <li class="active" data-under65="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.under %>" href="#">Under Age 65</a></li>\
+                  <li class="active" data-under65="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.under_65 %>" href="#">Under Age 65</a></li>\
                   <li><h1 class="text-center" style="margin:0">+</h1></li>\
-                  <li class="active" data-above65="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.above %>" href="#">Age 65 & Above</a></li>\
+                  <li class="active" data-above65="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.above_65 %>" href="#">Age 65 & Above</a></li>\
                 </ul>\
               </div>\
             </div>'),

--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -361,9 +361,9 @@ $(function() {
                 <br>\
                 <br>\
                 <ul id="age" class="nav nav-pills nav-justified">\
-                  <li class="active" data-under65="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.payroll %>" href="#">Under Age 65</a></li>\
+                  <li class="active" data-under65="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.under %>" href="#">Under Age 65</a></li>\
                   <li><h1 class="text-center" style="margin:0">+</h1></li>\
-                  <li class="active" data-65andabove="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.income %>" href="#">Age 65 & Above</a></li>\
+                  <li class="active" data-above65="false"><a data-toggle="tooltip" data-placement="bottom" title="<%= tooltips.above %>" href="#">Age 65 & Above</a></li>\
                 </ul>\
               </div>\
             </div>'),
@@ -392,6 +392,20 @@ $(function() {
                 var incometax = $el.data('incometax')
                 this.model.set('income_tax', incometax);
                 $el.data('incometax', !incometax);
+                $el.toggleClass('active');
+            },
+            'click [data-under65]': function(e) {
+                var $el = $(e.currentTarget);
+                var under65 = $el.data('under65');
+                this.model.set('under65', under65);
+                $el.data('under65', !under65);
+                $el.toggleClass('active');
+            },
+            'click [data-above65]': function(e) {
+                var $el = $(e.currentTarget);
+                var above65 = $el.data('above65')
+                this.model.set('above65', above65);
+                $el.data('above65', !above65);
                 $el.toggleClass('active');
             },
             'click [data-difference]': function(e) {

--- a/webapp/apps/constants.py
+++ b/webapp/apps/constants.py
@@ -15,6 +15,8 @@ METR_TOOLTIP = "Marginal effective tax rate on new investments. The METR include
 METTR_TOOLTIP = "Marginal effective total tax rate on new investments. The METTR includes the impact of all levels of taxation (both on business entities and savers) on the incentives to invest."
 COC_TOOLTIP = "The cost of capital is calculated as the net-of-depreciation, before-tax rate of return."
 DPRC_TOOLTIP = "Net present value of depreciation deductions."
+UBI_UNDER_TOOLTIP = "Include tax units under age 65."
+UBI_ABOVE_TOOLTIP = " Include tax units aged 65 and above."
 
 START_YEARS = ('2013', '2014', '2015', '2016', '2017', '2018')
 START_YEAR = os.environ.get('START_YEAR', '2017')

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -56,7 +56,8 @@ dynamic_compute = DynamicCompute()
 from ..constants import (DISTRIBUTION_TOOLTIP, DIFFERENCE_TOOLTIP,
                           PAYROLL_TOOLTIP, INCOME_TOOLTIP, BASE_TOOLTIP,
                           REFORM_TOOLTIP, INCOME_BINS_TOOLTIP,
-                          INCOME_DECILES_TOOLTIP, START_YEAR, START_YEARS)
+                          INCOME_DECILES_TOOLTIP, START_YEAR, START_YEARS,
+                          UBI_UNDER_TOOLTIP, UBI_ABOVE_TOOLTIP)
 
 from ..formatters import format_dynamic_params, get_version
 
@@ -786,7 +787,9 @@ def behavior_results(request, pk):
             'base': BASE_TOOLTIP,
             'reform': REFORM_TOOLTIP,
             'bins': INCOME_BINS_TOOLTIP,
-            'deciles': INCOME_DECILES_TOOLTIP
+            'deciles': INCOME_DECILES_TOOLTIP,
+            'under_65': UBI_UNDER_TOOLTIP,
+            'above_65': UBI_ABOVE_TOOLTIP
         }
         is_registered = True if request.user.is_authenticated() else False
         hostname = os.environ.get('BASE_IRI', 'http://www.ospc.org')

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -683,7 +683,7 @@ def get_result_context(model, request, url):
         'fiscal_reform': FISCAL_REFORM,
         'fiscal_change': FISCAL_CHANGE,
         'under_65': UBI_UNDER_TOOLTIP,
-        'above_65': UBI_ABOVE_TOOLTIP,
+        'above_65': UBI_ABOVE_TOOLTIP
     }
 
     if (model.json_text is not None and (model.json_text.raw_reform_text or

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -51,7 +51,8 @@ from ..constants import (DISTRIBUTION_TOOLTIP, DIFFERENCE_TOOLTIP,
                          REFORM_TOOLTIP, FISCAL_CURRENT_LAW, FISCAL_REFORM,
                          FISCAL_CHANGE, INCOME_BINS_TOOLTIP,
                          INCOME_DECILES_TOOLTIP, START_YEAR, START_YEARS,
-                         DATA_SOURCES, DEFAULT_SOURCE)
+                         DATA_SOURCES, DEFAULT_SOURCE, UBI_UNDER_TOOLTIP,
+                         UBI_ABOVE_TOOLTIP)
 
 from ..formatters import get_version
 from .param_formatters import (get_reform_from_file, get_reform_from_gui,
@@ -681,6 +682,8 @@ def get_result_context(model, request, url):
         'fiscal_current_law': FISCAL_CURRENT_LAW,
         'fiscal_reform': FISCAL_REFORM,
         'fiscal_change': FISCAL_CHANGE,
+        'under_65': UBI_UNDER_TOOLTIP,
+        'above_65': UBI_ABOVE_TOOLTIP,
     }
 
     if (model.json_text is not None and (model.json_text.raw_reform_text or


### PR DESCRIPTION
This PR adds an extra button to "build table" widget. The button set works similar to our current "payroll vs income" button, in the way that users could select either of them or both. When both "Under Age 65" and "Age 65 & Above" are selected, the table will render full data; when either one is selected, the respective data source would be rendered. Here's a preview of the button:

![screen shot 2018-03-20 at 2 28 06 pm](https://user-images.githubusercontent.com/13324931/37675349-6aa7a53c-2c4b-11e8-9841-31ba38202b04.png)

This PR needs further testing after desired data source is incorporated.