### PR TITLE
Add link to data document

### DIFF
--- a/templates/taxbrain/input_form.html
+++ b/templates/taxbrain/input_form.html
@@ -203,6 +203,8 @@
                   <li> <a href = "//ospc.org/docs" target="_blank">Read the Docs</a> </li>
                   <li> <a href = "//docs.google.com/forms/d/e/1FAIpQLSfvKEsQZNe9_16FhKNZcEyv3C8qXZhBfrqLxSd4VR97w92moQ/viewform" target="_blank">Leave Feedback</a> </li>
                   </ul>
+                  <h3>Datasets</h3>
+                  <p>TaxBrain now offers two data options for users: CPS and PUF. Borth datasets contain tax unit level data, but they do not have all of the same variables. As a result, some policy paramters will not be editable, depending on which dataset you choose. A more detailed breakdown of the differences between the file can be found <a href="https://github.com/open-source-economics/taxdata/blob/master/datasets.md">here</a>.</p>
                   <h3>Presets: key provisions from newsworthy proposals</h3>
                   <ul>
                   <li>The policy parameter presets are under review given the change in baseline parameters caused by the passage of the Tax Cuts and Jobs Act (TCJA).</li>

--- a/templates/taxbrain/input_form.html
+++ b/templates/taxbrain/input_form.html
@@ -204,7 +204,7 @@
                   <li> <a href = "//docs.google.com/forms/d/e/1FAIpQLSfvKEsQZNe9_16FhKNZcEyv3C8qXZhBfrqLxSd4VR97w92moQ/viewform" target="_blank">Leave Feedback</a> </li>
                   </ul>
                   <h3>Datasets</h3>
-                  <p>TaxBrain now offers two data options for users: CPS and PUF. Borth datasets contain tax unit level data, but they do not have all of the same variables. As a result, some policy paramters will not be editable, depending on which dataset you choose. A more detailed breakdown of the differences between the file can be found <a href="https://github.com/open-source-economics/taxdata/blob/master/datasets.md">here</a>.</p>
+                  <p>TaxBrain now offers users two data options: CPS and PUF. Both datasets contain tax unit level data, but they do not have all of the same variables. As a result, you will not be able to change some policy parameters, depending on which dataset you choose. A more detailed breakdown of the differences between the file can be found <a href="https://github.com/open-source-economics/taxdata/blob/master/datasets.md">here</a>.</p>
                   <h3>Presets: key provisions from newsworthy proposals</h3>
                   <ul>
                   <li>The policy parameter presets are under review given the change in baseline parameters caused by the passage of the Tax Cuts and Jobs Act (TCJA).</li>


### PR DESCRIPTION
Add a link to the data description doc to TaxBrain. Full text is:
>TaxBrain now offers users two data options: CPS and PUF. Both datasets contain tax unit level data, but they do not have all of the same variables. As a result, you will not be able to change some policy parameters, depending on which dataset you choose. A more detailed breakdown of the differences between the file can be found here.

cc @hdoupe @MattHJensen 