### PR TITLE
Update link to CCC guide

### DIFF
--- a/templates/btax/input_form.html
+++ b/templates/btax/input_form.html
@@ -157,7 +157,7 @@
 
                       <h1>Effective Tax Rate Calculations</h1>
 
-                      <p>The Cost of Capital Calculator produces estimates of the marginal effective tax rates on new investment under the baseline tax policy and user-specified tax reforms. These effective rate calculations take two forms. The marginal effective tax rate (METR) provides the tax wedge on new investment at the level of the business entity. The marginal effective total tax rate (METTR) includes individual level taxes in the measure of the tax wedge on new investment. One can think of the former as indicating the effect of taxes on incentives to invest from the perspective of the firm and the latter as representing effect of taxes on incentives to invest from the perspective of the saver.  For more detail on the calculations and assumptions underlying this model, please see the <a href = "https://github.com/open-source-economics/B-Tax/blob/master/Notes_and_Guides/CCC_Guide.pdf" target = "_blank"> CCC Guide</a>.</p>
+                      <p>The Cost of Capital Calculator produces estimates of the marginal effective tax rates on new investment under the baseline tax policy and user-specified tax reforms. These effective rate calculations take two forms. The marginal effective tax rate (METR) provides the tax wedge on new investment at the level of the business entity. The marginal effective total tax rate (METTR) includes individual level taxes in the measure of the tax wedge on new investment. One can think of the former as indicating the effect of taxes on incentives to invest from the perspective of the firm and the latter as representing effect of taxes on incentives to invest from the perspective of the saver.  For more detail on the calculations and assumptions underlying this model, please see the <a href = "https://github.com/open-source-economics/B-Tax/blob/master/Guides/CCC_Guide.pdf" target = "_blank"> CCC Guide</a>.</p>
 
                       <p><strong>Accuracy notes</strong></p>
 
@@ -172,7 +172,6 @@
                       Core Maintainers (static modeling)*:
                       <ul style = "list-style-type:none">
                       <li>- <a href = "http://www.jasondebacker.com" target = "blank" >Jason DeBacker, University of South Carolina</a></li>
-                      <li>- <a href = "https://github.com/bfgard" target = "blank" >Benjamin Gardner, Brigham Young University</a></li>
                       </ul>
                       </strong></p>
                       <p> These members have "write access" to the core modeling repositories, B-Tax, and work as a team to determine which open source contributions are accepted.</p>


### PR DESCRIPTION
This PR fixes a link that will be broken with the merge of [B-Tax PR #207](https://github.com/open-source-economics/B-Tax/pull/207).

It also removes Ben Gardner's name as a core maintainer.  I think this is safe to do since he's been off the project for more than 18 months.