### PR TITLE
Restore "Print" button for elasticity output page

### DIFF
--- a/templates/dynamic/elasticity_results.html
+++ b/templates/dynamic/elasticity_results.html
@@ -126,31 +126,24 @@
       <a href="/dynamic/macro/edit/{{ unique_url.pk }}/?start_year={{ first_year }}" class="text-white btn btn-secondary">Edit Parameters</a>
     </div>
 
-    <div class="result-table">
       <div class="result-table-controls">
         <div class="controls-tools">
-          <div class="btn-group">
-            <button type="button" class="btn btn-text btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-              Save As <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu" role="menu">
-              <li><a href="/taxbrain/pdf">PDF Report</a></li>
-              <li><a href="/taxbrain/{{ unique_url.pk }}/output.csv/">Outputs as CSV</a></li>
-              <li><a href="/taxbrain/{{ unique_url.pk }}/input.csv/">Inputs as CSV</a></li>
-            </ul>
-          </div>
-          <button class="btn btn-share btn-sm">Share</button>
-          <button class="btn btn-text btn-sm">Print</button>
+          <button onclick="printByID()" class="btn btn-text btn-sm">Print</button>
         </div>
       </div>
 
+    <div class="result-table" id="printTable">
       {% include 'taxbrain/includes/results/elasticity_table.html' with table=tables.elasticity_gdp %}
-
     </div>
 
     <div class="result-info"></div>
 
-
+    <script>
+    function printByID() {
+        var tab = document.getElementById("printTable").innerHTML;
+        alert(tab);
+    }
+    </script>
     <div class="push"></div>
 </div> <!-- /wrapper -->
 

--- a/templates/dynamic/elasticity_results.html
+++ b/templates/dynamic/elasticity_results.html
@@ -141,11 +141,8 @@
     <script>
     function printByID() {
         var tab = document.getElementById("printTable").innerHTML;
-        var win = window.open('', 'Print', 'height=600,width=800');
-
+        var win = window.open('', 'Print');
         win.document.write(tab);
-
-
         win.document.close();
         win.focus()
         win.print();

--- a/templates/dynamic/elasticity_results.html
+++ b/templates/dynamic/elasticity_results.html
@@ -141,7 +141,16 @@
     <script>
     function printByID() {
         var tab = document.getElementById("printTable").innerHTML;
-        alert(tab);
+        var win = window.open('', 'Print', 'height=600,width=800');
+
+        win.document.write(tab);
+
+
+        win.document.close();
+        win.focus()
+        win.print();
+        win.close();
+        return true;
     }
     </script>
     <div class="push"></div>

--- a/templates/taxbrain/includes/results/elasticity_table.html
+++ b/templates/taxbrain/includes/results/elasticity_table.html
@@ -19,9 +19,6 @@
           {% for col in table.cols %}
             <th>
               {{col.label}}
-              <div class="units">
-                {{ col.divisor|scales_of_units:col.units }}
-              </div>
             </th>
           {% endfor %}
         </tr>


### PR DESCRIPTION
I removed all non-functional buttons for the elasticity result page for the moment. I also plan to permanently get rid of the "Save As" drop-down whose options don't make much sense in my opinion.

I re-organized the div element a bit so that the table can be properly accessed, and was able to have the "Print" button semi-working. Here's how the page would look like:

![screen shot 2018-03-22 at 4 36 24 pm](https://user-images.githubusercontent.com/13324931/37797104-5201ec90-2def-11e8-88ac-09875c600a06.png)
A new window would pop-out with the same content in the table that allows you to print/save. I plan to polish the table layout a bit which would complete this button. 


