### PR TITLE
Updates job time and adds version to docker files

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,6 +19,7 @@ Release 1.5.0 on 2018-03-2?
 - [#854](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/854) - Change "About _ remaining" to "Estimated time remaining: _" - Max Ghenis
 - [#856](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/856) - Add link to data document - Anderson Frailey
 - [#857](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/857) - Update link to CCC guide - Jason DeBacker
+- [#863](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/857) - Updates job time and adds version to docker files - Hank Doupe
 
 **Bug Fixes**
 - [#844](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/842) - Pass start year to dynamic behavioral - Hank Doupe

--- a/distributed/Dockerfile.celery
+++ b/distributed/Dockerfile.celery
@@ -1,4 +1,4 @@
-FROM opensourcepolicycenter/distributed:latest
+FROM opensourcepolicycenter/distributed:v1.5.0
 
 LABEL build="celery" version="0.0.1" date="2018-03-22"
 

--- a/distributed/Dockerfile.flask
+++ b/distributed/Dockerfile.flask
@@ -1,4 +1,4 @@
-FROM opensourcepolicycenter/distributed:0.15.0
+FROM opensourcepolicycenter/distributed:v1.5.0
 
 LABEL build="flask" version="0.0.1" date="2018-03-22"
 

--- a/distributed/Dockerfile.flask
+++ b/distributed/Dockerfile.flask
@@ -1,4 +1,4 @@
-FROM opensourcepolicycenter/distributed:latest
+FROM opensourcepolicycenter/distributed:0.15.0
 
 LABEL build="flask" version="0.0.1" date="2018-03-22"
 

--- a/distributed/docker-compose.yml
+++ b/distributed/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3'
 services:
   flask:
-    image: opensourcepolicycenter/flask:latest
+    image: opensourcepolicycenter/flask:v1.5.0
     ports:
       - 5050:5050
     depends_on:
       - redis
   celery:
-    image: opensourcepolicycenter/celery:latest
+    image: opensourcepolicycenter/celery:v1.5.0
     depends_on:
       - redis
   redis:

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -65,7 +65,7 @@ tcversion_info = taxcalc._version.get_versions()
 
 TAXCALC_VERSION = tcversion_info['version']
 
-JOB_PROC_TIME_IN_SECONDS = 30
+JOB_PROC_TIME_IN_SECONDS = 90
 
 OUT_OF_RANGE_ERROR_MSG = ("Some fields have warnings or errors. Values "
                           "outside of suggested ranges will be accepted if "


### PR DESCRIPTION
This PR bumps up the job processing time form 30 seconds to 90 seconds. See #861 for more information on this. 

This PR also tags the docker images. This allows us to know the exact state of the workers for each version of PolicyBrain (which I am pretty pumped about).