### PR TITLE
Change Dropdown Order

### DIFF
--- a/webapp/apps/constants.py
+++ b/webapp/apps/constants.py
@@ -18,7 +18,7 @@ DPRC_TOOLTIP = "Net present value of depreciation deductions."
 
 START_YEARS = ('2013', '2014', '2015', '2016', '2017', '2018')
 START_YEAR = os.environ.get('START_YEAR', '2017')
-DATA_SOURCES = ('CPS', 'PUF')
+DATA_SOURCES = ('PUF', 'CPS')
 DEFAULT_SOURCE = os.environ.get('DEFAULT_SOURCE', 'PUF')
 
 TAXCALC_VERS_RESULTS_BACKWARDS_INCOMPATIBLE = "0.13.0"


### PR DESCRIPTION
This PR changes the order of the Data Source dropdown in TaxBrain so that `PUF` is the first option.