### PR TITLE
Back-end for not_avail.html page

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -30,6 +30,8 @@ Release 1.5.0 on 2018-03-2?
 - [#865](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/865) - Extend tests and fix warning/error handling regression - Hank Doupe
 - [#868](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/868) - Remove special processing for AMT parameters - Hank Doupe
 - [#870](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/870) - Update RELEASES.md and increase compute time to 100 seconds - Hank Doupe
+- [#874](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/874) - Add special HTML pages for when a model result is not found or is incompatible - Sean Wang
+- [#875](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/875) - Back-end for not_avail.html page - Hank Doupe
 
 Release 1.4.4 on 2018-03-08
 ----------------------------

--- a/templates/btax/not_avail.html
+++ b/templates/btax/not_avail.html
@@ -5,7 +5,7 @@
 
 <h3>
     We are unable to display the results for this simulation. We apologize for the inconvenience and are working to
-    provide a satisfactory solution for displaying and/or recovering results created using older versions of
+    provide a satisfactory solution for displaying or recovering results created using older versions of
     PolicyBrain. Here is one option for re-creating your results:
 </h2>
 

--- a/templates/btax/not_avail.html
+++ b/templates/btax/not_avail.html
@@ -18,7 +18,7 @@
 
 <h3>
     The B-Tax package may have more options for re-creating results with the exact version of
-    the package used in this run. For more details, please contact the OSPC team.
+    the package used in this run. For more details, please <a href="https://www.ospc.org/hello/"> contact the OSPC team. </a>
 </h3>
 
 </div>

--- a/templates/btax/not_avail.html
+++ b/templates/btax/not_avail.html
@@ -10,7 +10,7 @@
 </h2>
 
 <h3>
-    Go to the <a href=http://www.ospc.org/ccc/edit/{{ unique_url.pk }}/?start_year={{fill_in_start_year}}>input page</a> and
+    Go to the <a href = {{ edit_href }}>input page</a> and
     re-submit your parameters using the current version of PolicyBrain. Note that for older runs
     some parameters may have been deprecated. We recommend
     <a href="https://github.com/open-source-economics/B-Tax/tree/{{btax_version}}"> B-tax's</a> documentation for alternative parameter choices.

--- a/templates/btax/not_avail.html
+++ b/templates/btax/not_avail.html
@@ -4,7 +4,7 @@
 <div class="container">
 
 <h3>
-    We are unable to display the results for model run #XXX. We apologize for the inconvenience and are working to
+    We are unable to display the results for this simulation. We apologize for the inconvenience and are working to
     provide a satisfactory solution for displaying and/or recovering results created using older versions of
     PolicyBrain. Here is one option for re-creating your results:
 </h2>

--- a/templates/btax/not_avail.html
+++ b/templates/btax/not_avail.html
@@ -13,11 +13,11 @@
     Go to the <a href = {{ edit_href }}>input page</a> and
     re-submit your parameters using the current version of PolicyBrain. Note that for older runs
     some parameters may have been deprecated. We recommend
-    <a href="https://github.com/open-source-economics/B-Tax/tree/{{btax_version}}"> B-tax's</a> documentation for alternative parameter choices.
+    <a href="https://github.com/open-source-economics/B-Tax/tree/{{btax_version}}"> B-Tax's</a> documentation for alternative parameter choices.
 </h3>
 
 <h3>
-    The B-tax package may have more options for re-creating results with the exact version of
+    The B-Tax package may have more options for re-creating results with the exact version of
     the package used in this run. For more details, please contact the OSPC team.
 </h3>
 

--- a/templates/btax/not_avail.html
+++ b/templates/btax/not_avail.html
@@ -18,7 +18,7 @@
 
 <h3>
     The B-Tax package may have more options for re-creating results with the exact version of
-    the package used in this run. For more details, please <a href="https://www.ospc.org/hello/"> contact the OSPC team. </a>
+    B-Tax used in this simulation. For more details, please <a href="https://www.ospc.org/hello/"> contact the OSPC team. </a>
 </h3>
 
 </div>

--- a/templates/taxbrain/not_avail.html
+++ b/templates/taxbrain/not_avail.html
@@ -18,7 +18,7 @@
 
 <h3>
     The Tax-Calculator package may have more options for re-creating results with the exact version of
-    the package used in this run. For more details, please contact the OSPC team.
+    the package used in this run. For more details, please <a href="https://www.ospc.org/hello/"> contact the OSPC team. </a>
 </h3>
 
 </div>

--- a/templates/taxbrain/not_avail.html
+++ b/templates/taxbrain/not_avail.html
@@ -5,7 +5,7 @@
 
 <h3>
     We are unable to display the results for this simulation. We apologize for the inconvenience and are working to
-    provide a satisfactory solution for displaying and/or recovering results created using older versions of
+    provide a satisfactory solution for displaying or recovering results created using older versions of
     PolicyBrain. Here is one option for re-creating your results:
 </h2>
 

--- a/templates/taxbrain/not_avail.html
+++ b/templates/taxbrain/not_avail.html
@@ -4,7 +4,7 @@
 <div class="container">
 
 <h3>
-    We are unable to display the results for model run #XXX. We apologize for the inconvenience and are working to
+    We are unable to display the results for this simulation. We apologize for the inconvenience and are working to
     provide a satisfactory solution for displaying and/or recovering results created using older versions of
     PolicyBrain. Here is one option for re-creating your results:
 </h2>

--- a/templates/taxbrain/not_avail.html
+++ b/templates/taxbrain/not_avail.html
@@ -10,7 +10,7 @@
 </h2>
 
 <h3>
-    Go to the <a href=http://www.ospc.org/taxbrain/edit/{{ unique_url.pk }}/?start_year={{fill_in_start_year}}>input page</a> and
+    Go to the <a href="{{edit_href}}">input page</a> and
     re-submit your parameters using the current version of PolicyBrain. Note that for older runs
     some parameters may have been deprecated. We recommend
     <a href="https://github.com/open-source-economics/Tax-Calculator/tree/{{taxcalc_version}}"> Tax-Calculator's</a> documentation for alternative parameter choices.

--- a/templates/taxbrain/not_avail.html
+++ b/templates/taxbrain/not_avail.html
@@ -18,7 +18,7 @@
 
 <h3>
     The Tax-Calculator package may have more options for re-creating results with the exact version of
-    the package used in this run. For more details, please <a href="https://www.ospc.org/hello/"> contact the OSPC team. </a>
+    Tax-Caclulator used in this simulation. For more details, please <a href="https://www.ospc.org/hello/"> contact the OSPC team. </a>
 </h3>
 
 </div>


### PR DESCRIPTION
This PR adds renders the `not_avail.html` page (see #874) when an error is thrown while rendering simulation results.

For TaxBrain:

![screen shot 2018-03-28 at 11 36 05 am](https://user-images.githubusercontent.com/9206065/38039939-64525970-327c-11e8-998d-e46fcd5f3d44.png)

For CCC:

![screen shot 2018-03-28 at 11 36 43 am](https://user-images.githubusercontent.com/9206065/38039951-6b443ce4-327c-11e8-99d6-c75ae067389b.png)
