### PR TITLE
Use current default start year if start year was not saved

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -32,6 +32,7 @@ Release 1.5.0 on 2018-03-2?
 - [#870](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/870) - Update RELEASES.md and increase compute time to 100 seconds - Hank Doupe
 - [#874](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/874) - Add special HTML pages for when a model result is not found or is incompatible - Sean Wang
 - [#875](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/875) - Back-end for not_avail.html page - Hank Doupe
+- [#876](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/876) - Use current default start year if start year was not saved - Hank Doupe
 
 Release 1.4.4 on 2018-03-08
 ----------------------------

--- a/webapp/apps/btax/views.py
+++ b/webapp/apps/btax/views.py
@@ -265,7 +265,7 @@ def edit_btax_results(request, pk):
     except:
         raise Http404
 
-    model = BTaxSaveInputs.objects.get(pk=url.model_pk)
+    model = url.unique_inputs
     start_year = model.first_year
     #Get the user-input from the model in a way we can render
     ser_model = serializers.serialize('json', [model])

--- a/webapp/apps/btax/views.py
+++ b/webapp/apps/btax/views.py
@@ -376,7 +376,7 @@ def output_detail(request, pk):
             traceback.print_exc()
             edit_href = '/ccc/edit/{}/?start_year={}'.format(
                 pk,
-                model.first_year
+                model.first_year or START_YEAR # sometimes first_year is None
             )
             print('edit_href', edit_href, pk, model.first_year)
             not_avail_context = dict(edit_href=edit_href,

--- a/webapp/apps/dynamic/models.py
+++ b/webapp/apps/dynamic/models.py
@@ -119,7 +119,7 @@ class DynamicBehaviorSaveInputs(DataSourceable, Fieldable, Resultable,
     NONPARAM_FIELDS = set(["job_ids", "jobs_not_ready", "first_year",
                            "tax_result", "raw_input_fields", "input_fields",
                            "creation_date", "id", "raw_input_fields",
-                           "input_fields"])
+                           "input_fields", "data_source"])
 
     def set_fields(self):
         """

--- a/webapp/apps/dynamic/models.py
+++ b/webapp/apps/dynamic/models.py
@@ -118,8 +118,7 @@ class DynamicBehaviorSaveInputs(DataSourceable, Fieldable, Resultable,
 
     NONPARAM_FIELDS = set(["job_ids", "jobs_not_ready", "first_year",
                            "tax_result", "raw_input_fields", "input_fields",
-                           "creation_date", "id", "raw_input_fields",
-                           "input_fields", "data_source"])
+                           "creation_date", "id", "data_source"])
 
     def set_fields(self):
         """

--- a/webapp/apps/dynamic/tests/test_behavioral.py
+++ b/webapp/apps/dynamic/tests/test_behavioral.py
@@ -128,12 +128,15 @@ class TestDynamicBehavioralViews(object):
         assert post["first_budget_year"] == int(START_YEAR)
         assert user_mods["behavior"][str(START_YEAR)]["_BE_sub"][0] == 0.25
 
-    def test_get_not_avail_page_renders(self):
+    @pytest.mark.parametrize(
+        'start_year,start_year_is_none',
+        [(2018, False), (2017, True)]
+    )
+    def test_get_not_avail_page_renders(self, start_year, start_year_is_none):
         """
         Make sure not_avail.html page is rendered if exception is thrown
         while parsing results
         """
-        start_year = 2018
         fields = get_post_data(start_year, _ID_BenefitSurtax_Switches=False)
         fields['BE_sub'] = ['0.25']
         fields["first_year"] = start_year
@@ -149,6 +152,8 @@ class TestDynamicBehavioralViews(object):
         model.input_fields = None
         model.deprecated_fields = None
         model.tax_result = "unrenderable"
+        if start_year_is_none:
+            model.first_year = None
         model.save()
         unique_url.unique_inputs = model
         unique_url.save()

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -818,7 +818,7 @@ def behavior_results(request, pk):
             traceback.print_exc()
             edit_href = '/dynamic/behavioral/edit/{}/?start_year={}'.format(
                 pk,
-                model.start_year
+                model.first_year or START_YEAR # sometimes first_year is None
             )
             not_avail_context = dict(edit_href=edit_href,
                                      **context_vers_disp)

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -451,7 +451,7 @@ def edit_dynamic_behavioral(request, pk):
     except:
         raise Http404
 
-    model = DynamicBehaviorSaveInputs.objects.get(pk=url.model_pk)
+    model = url.unique_inputs
     start_year = model.first_year
     model.set_fields()
     #Get the user-input from the model in a way we can render
@@ -491,7 +491,7 @@ def edit_dynamic_elastic(request, pk):
     except:
         raise Http404
 
-    model = DynamicElasticitySaveInputs.objects.get(pk=url.model_pk)
+    model = url.unique_inputs
     start_year = model.first_year
     #Get the user-input from the model in a way we can render
     ser_model = serializers.serialize('json', [model])

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -761,7 +761,7 @@ class TaxSaveInputs(DataSourceable, Fieldable, Resultable, models.Model):
     NONPARAM_FIELDS = set(["job_ids", "jobs_not_ready", "first_year", "quick_calc",
                            "tax_result", "raw_input_fields", "input_fields",
                            "json_text", "error_text", "creation_date", "id",
-                           "raw_input_fields", "input_fields"])
+                           "raw_input_fields", "input_fields", "data_source"])
 
     def set_fields(self):
         """

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -761,7 +761,7 @@ class TaxSaveInputs(DataSourceable, Fieldable, Resultable, models.Model):
     NONPARAM_FIELDS = set(["job_ids", "jobs_not_ready", "first_year", "quick_calc",
                            "tax_result", "raw_input_fields", "input_fields",
                            "json_text", "error_text", "creation_date", "id",
-                           "raw_input_fields", "input_fields", "data_source"])
+                           "data_source"])
 
     def set_fields(self):
         """

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -782,13 +782,15 @@ class TestTaxBrainViews(object):
                       "PT_exclusion_wage_limit"]:
             assert msg.format(param) in str(response.context["form"].errors)
 
-    def test_get_not_avail_page_renders(self):
+    @pytest.mark.parametrize(
+        'start_year,start_year_is_none',
+        [(2018, False), (2017, True)]
+    )
+    def test_get_not_avail_page_renders(self, start_year, start_year_is_none):
         """
         Make sure not_avail.html page is rendered if exception is thrown
         while parsing results
         """
-
-        start_year = 2018
         fields = get_post_data(start_year)
         fields["first_year"] = start_year
         unique_url = get_taxbrain_model(fields,
@@ -800,6 +802,8 @@ class TestTaxBrainViews(object):
         model.input_fields = None
         model.deprecated_fields = None
         model.tax_result = "unrenderable"
+        if start_year_is_none:
+            model.first_year = None
         model.save()
         unique_url.unique_inputs = model
         unique_url.save()

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -767,7 +767,7 @@ def output_detail(request, pk):
             traceback.print_exc()
             edit_href = '/taxbrain/edit/{}/?start_year={}'.format(
                 pk,
-                model.start_year
+                model.first_year or START_YEAR # sometimes first_year is None
             )
             not_avail_context = dict(edit_href=edit_href,
                                      **context_vers_disp)

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -521,7 +521,7 @@ def submit_micro(request, pk):
     except:
         raise Http404
 
-    model = TaxSaveInputs.objects.get(pk=url.model_pk)
+    model = url.unique_inputs
     start_year = model.start_year
     # This will be a new model instance so unset the primary key
     model.pk = None
@@ -602,7 +602,7 @@ def edit_personal_results(request, pk):
     except:
         raise Http404
 
-    model = TaxSaveInputs.objects.get(pk=url.model_pk)
+    model = url.unique_inputs
     start_year = model.first_year
     model.set_fields()
 


### PR DESCRIPTION
For some older runs, the start year was not saved. So, when you try to go to the edit parameters page from the `not_avail.html` page and don't have a start year, the link looks like: `/taxbrain/edit/100/?start_year=None` and you get the following error:
![screen shot 2018-03-29 at 1 37 55 pm](https://user-images.githubusercontent.com/9206065/38104226-8b504bb0-3356-11e8-86eb-73ae8a3f2f58.png)



The production database has about 700 out of 30000 runs with out a start year and all of them were created in 2014 or 2015. This PR uses the current default start year as the start year value. This may not be the most accurate. Perhaps, using the year from the creation date is more accurate. But, that solution adds more complexity to the code for a small sample of the runs. Also, I feel like using the current start year is the most transparent option. I'm open to other ideas though.