### PR TITLE
Check hostnames to make sure they are current before pinging them

### DIFF
--- a/webapp/apps/btax/models.py
+++ b/webapp/apps/btax/models.py
@@ -14,9 +14,10 @@ import datetime
 from ..taxbrain.models import (SeparatedValuesField,
                                CommaSeparatedField)
 
+from ..taxbrain.behaviors import Hostnameable
 
 
-class BTaxSaveInputs(models.Model):
+class BTaxSaveInputs(Hostnameable, models.Model):
     """
     This model contains all the parameters for the tax model and the tax
     result.

--- a/webapp/apps/btax/views.py
+++ b/webapp/apps/btax/views.py
@@ -41,7 +41,7 @@ from .helpers import (get_btax_defaults,
 from ..taxbrain.helpers import (format_csv,
                                 is_wildcard)
 from ..taxbrain.views import denormalize, normalize
-from .compute import DropqComputeBtax, MockComputeBtax, JobFailError
+from .compute import DropqComputeBtax, MockComputeBtax, JobFailError, BTAX_WORKERS
 
 from ..constants import (METTR_TOOLTIP, METR_TOOLTIP, COC_TOOLTIP, DPRC_TOOLTIP,
                         START_YEAR)
@@ -403,7 +403,10 @@ def output_detail(request, pk):
         return render(request, 'btax/results.html', context)
 
     else:
-
+        if not model.check_hostnames(BTAX_WORKERS):
+            print('bad hostname', model.jobs_not_ready, BTAX_WORKERS)
+            return render_to_response('taxbrain/failed.html',
+                                      context={'is_btax': True})
         job_ids = model.job_ids
         jobs_to_check = model.jobs_not_ready
         if not jobs_to_check:

--- a/webapp/apps/dynamic/models.py
+++ b/webapp/apps/dynamic/models.py
@@ -15,7 +15,8 @@ import taxcalc
 
 from ..taxbrain.models import (CommaSeparatedField, SeparatedValuesField,
                                TaxSaveInputs, OutputUrl)
-from ..taxbrain.behaviors import Resultable, Fieldable, DataSourceable
+from ..taxbrain.behaviors import (Resultable, Fieldable, DataSourceable,
+                                  Hostnameable)
 from ..taxbrain import helpers as taxbrain_helpers
 from ..taxbrain import param_formatters
 
@@ -60,8 +61,8 @@ class DynamicSaveInputs(DataSourceable, models.Model):
         )
 
 
-class DynamicBehaviorSaveInputs(DataSourceable, Fieldable, Resultable,
-                                models.Model):
+class DynamicBehaviorSaveInputs(DataSourceable, Fieldable,
+                                Resultable, Hostnameable, models.Model):
     """
     This model contains all the parameters for the dynamic behavioral tax
     model and the tax result.
@@ -147,7 +148,7 @@ class DynamicBehaviorSaveInputs(DataSourceable, Fieldable, Resultable,
         )
 
 
-class DynamicElasticitySaveInputs(DataSourceable, models.Model):
+class DynamicElasticitySaveInputs(DataSourceable, Hostnameable, models.Model):
     """
     This model contains all the parameters for the dynamic elasticity
     wrt GDP dynamic macro model and tax result

--- a/webapp/apps/dynamic/models.py
+++ b/webapp/apps/dynamic/models.py
@@ -61,8 +61,8 @@ class DynamicSaveInputs(DataSourceable, models.Model):
         )
 
 
-class DynamicBehaviorSaveInputs(DataSourceable, Fieldable,
-                                Resultable, Hostnameable, models.Model):
+class DynamicBehaviorSaveInputs(DataSourceable, Fieldable, Resultable,
+                                Hostnameable, models.Model):
     """
     This model contains all the parameters for the dynamic behavioral tax
     model and the tax result.

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -43,6 +43,7 @@ from ..taxbrain.param_formatters import (to_json_reform, get_reform_from_gui,
 from ..taxbrain.helpers import (taxcalc_results_to_tables,
                                 convert_val)
 from ..taxbrain.param_displayers import default_behavior
+from ..taxbrain.compute import JobFailError, DROPQ_WORKERS
 from .helpers import (default_parameters, job_submitted,
                       ogusa_results_to_tables, success_text,
                       failure_text, normalize, denormalize, strip_empty_lists,
@@ -650,7 +651,9 @@ def elastic_results(request, pk):
         return render(request, 'dynamic/elasticity_results.html', context)
 
     else:
-
+        if not model.check_hostnames(DROPQ_WORKERS):
+            print('bad hostname', model.jobs_not_ready, DROPQ_WORKERS)
+            raise render_to_response('taxbrain/failed.html')
         job_ids = model.job_ids
         jobs_to_check = model.jobs_not_ready
         if not jobs_to_check:
@@ -839,7 +842,9 @@ def behavior_results(request, pk):
         return render(request, 'taxbrain/results.html', context)
 
     else:
-
+        if not model.check_hostnames(DROPQ_WORKERS):
+            print('bad hostname', model.jobs_not_ready, DROPQ_WORKERS)
+            raise render_to_response('taxbrain/failed.html')
         job_ids = model.job_ids
         jobs_to_check = model.jobs_not_ready
         if not jobs_to_check:

--- a/webapp/apps/taxbrain/behaviors.py
+++ b/webapp/apps/taxbrain/behaviors.py
@@ -132,3 +132,24 @@ class DataSourceable(models.Model):
             return True
         else:
             return False
+
+
+class Hostnameable(models.Model):
+    """
+    Mix-in for providing functionality around hostnames
+    """
+    class Meta:
+        abstract = True
+
+    def check_hostnames(self, current_hostnames):
+        """
+        Make sure all hostnames are valid before posting to/getting data from
+        them
+        """
+        if self.jobs_not_ready is None:
+            return True
+        for id in self.jobs_not_ready:
+            hn = id.split('#')[1]
+            if hn not in current_hostnames:
+                return False
+        return True

--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -4,7 +4,7 @@ from .models import WorkerNodesCounter
 import json
 import requests
 import taxcalc
-from requests.exceptions import Timeout, RequestException
+from requests.exceptions import Timeout, RequestException, ConnectionError
 from .helpers import arrange_totals_by_row
 from ..constants import START_YEAR
 import requests_mock
@@ -316,6 +316,15 @@ class MockFailedCompute(MockCompute):
         with requests_mock.Mocker() as mock:
             mock.register_uri('GET', '/dropq_query_result', text='FAIL')
             return DropqCompute.remote_results_ready(self, theurl, params)
+
+class MockFailedComputeOnOldHost(MockCompute):
+
+    def remote_results_ready(self, theurl, params):
+        print 'MockFailedCompute remote_results_ready', theurl, params
+        with requests_mock.Mocker() as mock:
+            mock.register_uri('GET', '/dropq_query_result', text='FAIL')
+            raise requests.ConnectionError()
+
 
 class NodeDownCompute(MockCompute):
 

--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -318,12 +318,13 @@ class MockFailedCompute(MockCompute):
             return DropqCompute.remote_results_ready(self, theurl, params)
 
 class MockFailedComputeOnOldHost(MockCompute):
-
+    """
+    Simulate requesting results from a host IP that is no longer used. This
+    action should raise a `ConnectionError`
+    """
     def remote_results_ready(self, theurl, params):
-        print 'MockFailedCompute remote_results_ready', theurl, params
-        with requests_mock.Mocker() as mock:
-            mock.register_uri('GET', '/dropq_query_result', text='FAIL')
-            raise requests.ConnectionError()
+        print 'MockFailedComputeOnOldHost remote_results_ready', theurl, params
+        raise requests.ConnectionError()
 
 
 class NodeDownCompute(MockCompute):

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -17,7 +17,7 @@ import taxcalc
 import helpers
 import param_formatters
 
-from behaviors import Resultable, Fieldable, DataSourceable
+from behaviors import Resultable, Fieldable, DataSourceable, Hostnameable
 
 
 # digit or true/false (case insensitive)
@@ -86,7 +86,8 @@ class ErrorMessageTaxCalculator(models.Model):
     text = models.CharField(blank=True, null=False, max_length=4000)
 
 
-class TaxSaveInputs(DataSourceable, Fieldable, Resultable, models.Model):
+class TaxSaveInputs(DataSourceable, Fieldable, Resultable, Hostnameable,
+                    models.Model):
     """
     This model contains all the parameters for the tax model and the tax
     result.


### PR DESCRIPTION
New AWS instances were set up for PB 1.5.0. This PR fixes a case where the previous hostnames were pinged to check on an old, failed result. Instead of pinging the no longer used hostnames, we render a job failed page.