### PR TITLE
Add default parameter handling for macro elasticity simulation

### DIFF
--- a/webapp/apps/dynamic/tests/test_views.py
+++ b/webapp/apps/dynamic/tests/test_views.py
@@ -1,6 +1,5 @@
-
-from django.test import TestCase
 from django.test import Client
+import pytest
 import mock
 import os
 # os.environ["NUM_BUDGET_YEARS"] = '2'
@@ -15,12 +14,18 @@ from taxcalc import Policy
 START_YEAR = '2016'
 
 
-class DynamicViewsTests(TestCase):
+class DynamicViewsTests(object):
     ''' Test the views of this app. '''
 
     def setUp(self):
         # Every test needs a client.
         self.client = Client()
+
+    def assertEqual(self, a, b):
+        assert (a == b)
+
+    def assertTrue(self, a):
+        assert a
 
     def test_taxbrain_get(self):
         # Issue a GET request.
@@ -80,8 +85,12 @@ class DynamicViewsTests(TestCase):
         link_idx = response.url[:-1].rfind('/')
         self.assertTrue(response.url[:link_idx+1].endswith("behavior_results/"))
 
-
-    def test_elastic_post(self):
+    # Test whether default elasticity is used if no param is given
+    @pytest.mark.parametrize(
+        'el_data',
+        [{'elastic_gdp': ['0.55']}, {}]
+    )
+    def test_elastic_post(self, el_data):
         #Monkey patch to mock out running of compute jobs
         import sys
         from webapp.apps.taxbrain import views
@@ -121,7 +130,6 @@ class DynamicViewsTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Do the elasticity job submission
-        el_data = {'elastic_gdp': ['0.55']}
         response = self.client.post(dynamic_egdp, el_data)
         self.assertEqual(response.status_code, 302)
         print(response)

--- a/webapp/apps/dynamic/tests/test_views.py
+++ b/webapp/apps/dynamic/tests/test_views.py
@@ -21,18 +21,12 @@ class DynamicViewsTests(object):
         # Every test needs a client.
         self.client = Client()
 
-    def assertEqual(self, a, b):
-        assert (a == b)
-
-    def assertTrue(self, a):
-        assert a
-
     def test_taxbrain_get(self):
         # Issue a GET request.
         response = self.client.get('/taxbrain/')
 
         # Check that the response is 200 OK.
-        self.assertEqual(response.status_code, 200)
+        assert (response.status_code == 200)
 
     def test_behavioral_post(self):
         #Monkey patch to mock out running of compute jobs
@@ -57,33 +51,33 @@ class DynamicViewsTests(object):
 
         response = self.client.post('/taxbrain/', data)
         # Check that redirect happens
-        self.assertEqual(response.status_code, 302)
+        assert (response.status_code == 302)
         # Go to results page
         link_idx = response.url[:-1].rfind('/')
-        self.assertTrue(response.url[:link_idx+1].endswith("taxbrain/"))
+        assert response.url[:link_idx+1].endswith("taxbrain/")
 
         # Link to dynamic simulation
         model_num = response.url[link_idx+1:-1]
         dynamic_landing = '/dynamic/{0}/?start_year={1}'.format(model_num, START_YEAR)
         response = self.client.get(dynamic_landing)
-        self.assertEqual(response.status_code, 200)
+        assert (response.status_code == 200)
 
         # Go to behavioral input page
         dynamic_behavior = '/dynamic/behavioral/{0}/?start_year={1}'.format(model_num, START_YEAR)
         response = self.client.get(dynamic_behavior)
-        self.assertEqual(response.status_code, 200)
+        assert (response.status_code == 200)
 
         # Do the partial equilibrium job submission
         pe_data = {'BE_inc': ['-0.4']}
         response = self.client.post(dynamic_behavior, pe_data)
-        self.assertEqual(response.status_code, 302)
+        assert (response.status_code == 302)
         print(response)
 
         #Check should get success this time
         response_success = self.client.get(response.url)
-        self.assertEqual(response_success.status_code, 200)
+        assert (response_success.status_code == 200)
         link_idx = response.url[:-1].rfind('/')
-        self.assertTrue(response.url[:link_idx+1].endswith("behavior_results/"))
+        assert response.url[:link_idx+1].endswith("behavior_results/")
 
     # Test whether default elasticity is used if no param is given
     @pytest.mark.parametrize(
@@ -113,31 +107,31 @@ class DynamicViewsTests(object):
 
         response = self.client.post('/taxbrain/', data)
         # Check that redirect happens
-        self.assertEqual(response.status_code, 302)
+        assert (response.status_code == 302)
         # Go to results page
         link_idx = response.url[:-1].rfind('/')
-        self.assertTrue(response.url[:link_idx+1].endswith("taxbrain/"))
+        assert response.url[:link_idx+1].endswith("taxbrain/")
 
         # Link to dynamic simulation
         model_num = response.url[link_idx+1:-1]
         dynamic_landing = '/dynamic/{0}/?start_year={1}'.format(model_num, START_YEAR)
         response = self.client.get(dynamic_landing)
-        self.assertEqual(response.status_code, 200)
+        assert (response.status_code == 200)
 
         # Go to macro input page
         dynamic_egdp = '/dynamic/macro/{0}/?start_year={1}'.format(model_num, START_YEAR)
         response = self.client.get(dynamic_egdp)
-        self.assertEqual(response.status_code, 200)
+        assert (response.status_code == 200)
 
         # Do the elasticity job submission
         response = self.client.post(dynamic_egdp, el_data)
-        self.assertEqual(response.status_code, 302)
+        assert (response.status_code == 302)
         print(response)
 
         #Check that we get success this time
         response_success = self.client.get(response.url)
-        self.assertEqual(response_success.status_code, 200)
-        self.assertTrue(response.url[:-2].endswith("macro_results/"))
+        assert (response_success.status_code == 200)
+        assert response.url[:-2].endswith("macro_results/")
 
     def test_elastic_failed_job(self):
         #Monkey patch to mock out running of compute jobs
@@ -163,33 +157,32 @@ class DynamicViewsTests(object):
 
         response = self.client.post('/taxbrain/', data)
         # Check that redirect happens
-        self.assertEqual(response.status_code, 302)
+        assert (response.status_code == 302)
         # Go to results page
         link_idx = response.url[:-1].rfind('/')
-        self.assertTrue(response.url[:link_idx+1].endswith("taxbrain/"))
+        assert response.url[:link_idx+1].endswith("taxbrain/")
 
         # Link to dynamic simulation
         model_num = response.url[link_idx+1:-1]
         dynamic_landing = '/dynamic/{0}/?start_year={1}'.format(model_num, START_YEAR)
         response = self.client.get(dynamic_landing)
-        self.assertEqual(response.status_code, 200)
+        assert (response.status_code == 200)
 
         # Go to macro input page
         dynamic_egdp = '/dynamic/macro/{0}/?start_year={1}'.format(model_num, START_YEAR)
         response = self.client.get(dynamic_egdp)
-        self.assertEqual(response.status_code, 200)
+        assert (response.status_code == 200)
 
         # Do the elasticity job submission
         el_data = {'elastic_gdp': ['0.55']}
         response = self.client.post(dynamic_egdp, el_data)
-        self.assertEqual(response.status_code, 302)
+        assert (response.status_code == 302)
         print(response)
 
         #Check that we get success this time
         response_success = self.client.get(response.url)
-        self.assertEqual(response_success.status_code, 200)
-        self.assertTrue(response.url[:-2].endswith("macro_results/"))
+        assert (response_success.status_code == 200)
+        assert response.url[:-2].endswith("macro_results/")
         response = self.client.get(response.url)
         # Make sure the failure message is in the response
-        self.assertTrue("Your calculation failed"
-                        in response.content.decode('utf-8'))
+        assert ("Your calculation failed" in response.content.decode('utf-8'))

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -338,9 +338,19 @@ def dynamic_elasticities(request, pk):
     start_year = START_YEAR
     if request.method=='POST':
         # Client is attempting to send inputs, validate as form data
-        fields = dict(request.GET)
-        fields.update(dict(request.POST))
-        fields = {k: v[0] if isinstance(v, list) else v for k, v in list(fields.items())}
+        init_fields = dict(request.GET)
+        init_fields.update(dict(request.POST))
+
+        fields = {}
+        for k, v in list(init_fields.items()):
+            if isinstance(v, list):
+                v = v[0]
+            if not v:
+                v = (default_elasticity_parameters(int(start_year))[k]
+                     .col_fields[0]
+                     .default_value)
+            fields[k] = v
+
         start_year = fields.get('start_year', START_YEAR)
         print(fields)
         # TODO: migrate first_year to start_year to get rid of weird stuff like


### PR DESCRIPTION
Add default parameter handling for macro elasticity simulation. Follow-up to #883 and #905: currently, running the macro elasticity model without inputting any data results in not even a UI error, but an uncaught server error in converting an empty string to a float. This adds default handling in a general way. However, it does make the assumption that there is only one column/value per input; this was already implied in the previous code, and I believe that should be okay for this model, but please let me know if it is not.