### PR TITLE
Change datetime objects to timezone-aware ones

### DIFF
--- a/webapp/apps/btax/models.py
+++ b/webapp/apps/btax/models.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User
 
 from django.contrib.postgres.fields import JSONField
 import datetime
+from django.utils.timezone import make_aware
 
 from ..taxbrain.models import (SeparatedValuesField,
                                CommaSeparatedField)
@@ -120,7 +121,9 @@ class BTaxSaveInputs(Hostnameable, models.Model):
     # Result
     tax_result = models.TextField(default=None, blank=True, null=True)
     # Creation DateTime
-    creation_date = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    creation_date = models.DateTimeField(
+                        default=make_aware(datetime.datetime(2015, 1, 1))
+                    )
 
 
     class Meta:
@@ -138,7 +141,9 @@ class BTaxOutputUrl(models.Model):
     user = models.ForeignKey(User, null=True, default=None)
     model_pk = models.IntegerField(default=None, null=True)
     # Expected Completion DateTime
-    exp_comp_datetime = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    exp_comp_datetime = models.DateTimeField(
+                            default=make_aware(datetime.datetime(2015, 1, 1))
+                        )
     uuid = models.UUIDField(default=uuid.uuid4, null=True, editable=False, max_length=32, blank=True, unique=True)
     btax_vers = models.CharField(blank=True, default=None, null=True, max_length=50)
     taxcalc_vers = models.CharField(blank=True, default=None, null=True, max_length=50)

--- a/webapp/apps/dynamic/models.py
+++ b/webapp/apps/dynamic/models.py
@@ -21,6 +21,7 @@ from ..taxbrain import helpers as taxbrain_helpers
 from ..taxbrain import param_formatters
 
 import datetime
+from django.utils.timezone import make_aware
 
 
 class DynamicSaveInputs(DataSourceable, models.Model):
@@ -47,7 +48,10 @@ class DynamicSaveInputs(DataSourceable, models.Model):
     # Result
     tax_result = JSONField(default=None, blank=True, null=True)
     # Creation DateTime
-    creation_date = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    creation_date = models.DateTimeField(
+                        default=make_aware(datetime.datetime(2015, 1, 1))
+                    )
+
     # Email address for user who started this job
     user_email = models.CharField(blank=True, default=None, null=True,
                                   max_length=50)
@@ -91,7 +95,9 @@ class DynamicBehaviorSaveInputs(DataSourceable, Fieldable, Resultable,
     # Result
     tax_result = JSONField(default=None, blank=True, null=True)
     # Creation DateTime
-    creation_date = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    creation_date = models.DateTimeField(
+                        default=make_aware(datetime.datetime(2015, 1, 1))
+                    )
 
     micro_sim = models.ForeignKey(OutputUrl, blank=True, null=True,
                                   on_delete=models.SET_NULL)
@@ -166,7 +172,9 @@ class DynamicElasticitySaveInputs(DataSourceable, Hostnameable, models.Model):
     # Result
     tax_result = JSONField(default=None, blank=True, null=True)
     # Creation DateTime
-    creation_date = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    creation_date = models.DateTimeField(
+                        default=make_aware(datetime.datetime(2015, 1, 1))
+                    )
 
     micro_sim = models.ForeignKey(OutputUrl, blank=True, null=True,
                                   on_delete=models.SET_NULL)
@@ -217,7 +225,9 @@ class DynamicBehaviorOutputUrl(models.Model):
     user = models.ForeignKey(User, null=True, default=None)
     model_pk = models.IntegerField(default=None, null=True)
     # Expected Completion DateTime
-    exp_comp_datetime = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    exp_comp_datetime = models.DateTimeField(
+                            default=make_aware(datetime.datetime(2015, 1, 1))
+                        )
     uuid = models.UUIDField(default=uuid.uuid4, null=True, editable=False, max_length=32, blank=True, unique=True)
     taxcalc_vers = models.CharField(blank=True, default=None, null=True,
         max_length=50)
@@ -239,7 +249,9 @@ class DynamicElasticityOutputUrl(models.Model):
     user = models.ForeignKey(User, null=True, default=None)
     model_pk = models.IntegerField(default=None, null=True)
     # Expected Completion DateTime
-    exp_comp_datetime = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    exp_comp_datetime = models.DateTimeField(
+                            default=make_aware(datetime.datetime(2015, 1, 1))
+                        )
     uuid = models.UUIDField(default=uuid.uuid4, null=True, editable=False, max_length=32, blank=True, unique=True)
     taxcalc_vers = models.CharField(blank=True, default=None, null=True,
         max_length=50)

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -1,6 +1,6 @@
 import json
-import pytz
 import datetime
+from django.utils import timezone
 from urllib.parse import urlparse, parse_qs
 import os
 #Mock some module for imports because we can't fit them on Heroku slugs
@@ -277,7 +277,7 @@ def dynamic_behavioral(request, pk):
 
                 unique_url.unique_inputs = model
                 unique_url.model_pk = model.pk
-                cur_dt = datetime.datetime.utcnow()
+                cur_dt = timezone.now()
                 future_offset = datetime.timedelta(seconds=((2 + max_q_length) * JOB_PROC_TIME_IN_SECONDS))
                 expected_completion = cur_dt + future_offset
                 unique_url.exp_comp_datetime = expected_completion
@@ -423,7 +423,7 @@ def dynamic_elasticities(request, pk):
                 unique_url.unique_inputs = model
                 unique_url.model_pk = model.pk
 
-                cur_dt = datetime.datetime.utcnow()
+                cur_dt = timezone.now()
                 future_offset = datetime.timedelta(seconds=((2 + max_q_length) * JOB_PROC_TIME_IN_SECONDS))
                 expected_completion = cur_dt + future_offset
                 unique_url.exp_comp_datetime = expected_completion
@@ -578,7 +578,7 @@ def dynamic_finished(request):
     submitted_ids = normalize(job_ids)
     result = dynamic_compute.ogusa_get_results(submitted_ids, status=status)
     dsi.tax_result = result
-    dsi.creation_date = datetime.datetime.now()
+    dsi.creation_date = timezone.now()
     dsi.save()
 
     params = dynamic_params_from_model(dsi)
@@ -702,7 +702,7 @@ def elastic_results(request, pk):
 
         if all([job == 'YES' for job in jobs_ready]):
             model.tax_result = dropq_compute.elastic_get_results(normalize(job_ids))
-            model.creation_date = datetime.datetime.now()
+            model.creation_date = timezone.now()
             model.save()
             return redirect(url)
 
@@ -715,8 +715,7 @@ def elastic_results(request, pk):
             if request.method == 'POST':
                 # if not ready yet, insert number of minutes remaining
                 exp_comp_dt = url.exp_comp_datetime
-                utc_now = datetime.datetime.utcnow()
-                utc_now = utc_now.replace(tzinfo=pytz.utc)
+                utc_now = timezone.now()
                 dt = exp_comp_dt - utc_now
                 exp_num_minutes = dt.total_seconds() / 60.
                 exp_num_minutes = round(exp_num_minutes, 2)
@@ -898,7 +897,7 @@ def behavior_results(request, pk):
         if all([job == 'YES' for job in jobs_ready]):
             results = dropq_compute.dropq_get_results(normalize(job_ids))
             model.tax_result = results
-            model.creation_date = datetime.datetime.now()
+            model.creation_date = timezone.now()
             model.save()
             return redirect('behavior_results', url.pk)
         else:
@@ -910,8 +909,7 @@ def behavior_results(request, pk):
             if request.method == 'POST':
                 # if not ready yet, insert number of minutes remaining
                 exp_comp_dt = url.exp_comp_datetime
-                utc_now = datetime.datetime.utcnow()
-                utc_now = utc_now.replace(tzinfo=pytz.utc)
+                utc_now = timezone.now()
                 dt = exp_comp_dt - utc_now
                 exp_num_minutes = dt.total_seconds() / 60.
                 exp_num_minutes = round(exp_num_minutes, 2)

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 
 from django.contrib.postgres.fields import JSONField, ArrayField
 import datetime
+from django.utils.timezone import make_aware
 
 import taxcalc
 
@@ -761,7 +762,9 @@ class TaxSaveInputs(DataSourceable, Fieldable, Resultable, Hostnameable,
     error_text = models.ForeignKey(ErrorMessageTaxCalculator, null=True, default=None, blank=True)
 
     # Creation DateTime
-    creation_date = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    creation_date = models.DateTimeField(
+                        default=make_aware(datetime.datetime(2015, 1, 1))
+                    )
 
     def get_tax_result(self):
         """
@@ -834,7 +837,9 @@ class OutputUrl(models.Model):
     user = models.ForeignKey(User, null=True, default=None)
     model_pk = models.IntegerField(default=None, null=True)
     # Expected Completion DateTime
-    exp_comp_datetime = models.DateTimeField(default=datetime.datetime(2015, 1, 1))
+    exp_comp_datetime = models.DateTimeField(
+                            default=make_aware(datetime.datetime(2015, 1, 1))
+                        )
     uuid = models.UUIDField(default=uuid.uuid4, null=True, editable=False, max_length=32, blank=True, unique=True)
     taxcalc_vers = models.CharField(blank=True, default=None, null=True,
         max_length=50)

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -2,7 +2,6 @@
 import csv
 import pdfkit
 import json
-import pytz
 import os
 import tempfile
 import re
@@ -15,6 +14,7 @@ import sys
 
 import taxcalc
 import datetime
+from django.utils import timezone
 import logging
 from urllib.parse import urlparse, parse_qs
 from ipware.ip import get_real_ip
@@ -131,7 +131,7 @@ def save_model(post_meta):
 
     unique_url.unique_inputs = model
     unique_url.model_pk = model.pk
-    cur_dt = datetime.datetime.utcnow()
+    cur_dt = timezone.now()
     future_offset_seconds = ((2 + post_meta.max_q_length)
                              * JOB_PROC_TIME_IN_SECONDS)
     future_offset = datetime.timedelta(seconds=future_offset_seconds)
@@ -824,7 +824,7 @@ def output_detail(request, pk):
         if all(j == 'YES' for j in jobs_ready):
             results = dropq_compute.dropq_get_results(normalize(job_ids))
             model.tax_result = results
-            model.creation_date = datetime.datetime.now()
+            model.creation_date = timezone.now()
             model.save()
             context = get_result_context(model, request, url)
             context.update(context_vers_disp)
@@ -840,8 +840,7 @@ def output_detail(request, pk):
             if request.method == 'POST':
                 # if not ready yet, insert number of minutes remaining
                 exp_comp_dt = url.exp_comp_datetime
-                utc_now = datetime.datetime.utcnow()
-                utc_now = utc_now.replace(tzinfo=pytz.utc)
+                utc_now = timezone.now()
                 dt = exp_comp_dt - utc_now
                 exp_num_minutes = dt.total_seconds() / 60.
                 exp_num_minutes = round(exp_num_minutes, 2)
@@ -870,7 +869,7 @@ def csv_output(request, pk):
 
     # Create the HttpResponse object with the appropriate CSV header.
     response = HttpResponse(content_type='text/csv')
-    now = datetime.datetime.now()
+    now = timezone.now()
     suffix = "".join(map(str, [now.year, now.month, now.day, now.hour,
                                now.minute, now.second]))
     filename = "taxbrain_outputs_" + suffix + ".csv"
@@ -907,7 +906,7 @@ def csv_input(request, pk):
 
     # Create the HttpResponse object with the appropriate CSV header.
     response = HttpResponse(content_type='text/csv')
-    now = datetime.datetime.now()
+    now = timezone.now()
     suffix = "".join(map(str, [now.year, now.month, now.day, now.hour,
                                now.minute, now.second]))
     filename = "taxbrain_inputs_" + suffix + ".csv"

--- a/webapp/apps/test_assets/test_models.py
+++ b/webapp/apps/test_assets/test_models.py
@@ -4,7 +4,7 @@ import json
 import os
 import pytest
 import numpy as np
-from datetime import datetime
+from django.utils import timezone
 
 from ..taxbrain.models import (JSONReformTaxCalculator,
                                OutputUrl, TaxSaveInputs)
@@ -38,7 +38,7 @@ class TaxBrainTableResults(TaxBrainModelsTest):
 
         model = unique_url.unique_inputs
         model.tax_result = self.skelaton_res_lt_0130
-        model.creation_date = datetime.now()
+        model.creation_date = timezone.now()
         model.save()
 
         np.testing.assert_equal(model.get_tax_result(),
@@ -52,7 +52,7 @@ class TaxBrainTableResults(TaxBrainModelsTest):
 
         model = unique_url.unique_inputs
         model.tax_result = self.skelaton_res_gt_0130
-        model.creation_date = datetime.now()
+        model.creation_date = timezone.now()
         model.save()
 
         np.testing.assert_equal(model.get_tax_result(),

--- a/webapp/apps/test_assets/utils.py
+++ b/webapp/apps/test_assets/utils.py
@@ -146,7 +146,8 @@ def get_file_post_data(start_year, reform_text, assumptions_text=None, quick_cal
 
 def get_taxbrain_model(_fields, first_year=2017,
                        quick_calc=False, taxcalc_vers="0.13.0",
-                       webapp_vers="1.2.0", exp_comp_datetime = "2017-10-10",
+                       webapp_vers="1.2.0",
+                       exp_comp_datetime="2017-10-10T00:00:00+00:00",
                        Form=TaxBrainForm, UrlModel=OutputUrl,
                        use_puf_not_cps=True):
     fields = _fields.copy()


### PR DESCRIPTION
Change naive datetime objects to timezone-aware ones. This has the advantage of fixing 200+ warnings when running the tests, and everything seems to work with this change.