### PR TITLE
Cleans up input parameter save and display logic for dynamic app

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,7 @@ Release 1.7.0 on 2018-06-??
 
 **Bug Fixes**
 - [#904](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/904) - Fix formatting of the first line in CSV output for better compatibility - Lucas Szwarcberg
+- [#912](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/912) - Cleans up input parameter save and display logic for dyanamic app - Hank Doupe
 
 Release 1.6.0 on 2018-06-13
 ----------------------------

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,7 +22,7 @@ Release 1.7.0 on 2018-06-??
 
 **Bug Fixes**
 - [#904](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/904) - Fix formatting of the first line in CSV output for better compatibility - Lucas Szwarcberg
-- [#912](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/912) - Cleans up input parameter save and display logic for dyanamic app - Hank Doupe
+- [#912](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pull/912) - Cleans up input parameter save and display logic for dynamic app - Hank Doupe
 
 Release 1.6.0 on 2018-06-13
 ----------------------------

--- a/templates/taxbrain/results.html
+++ b/templates/taxbrain/results.html
@@ -81,12 +81,6 @@
           {%autoescape off %}
           {{ reform_file_contents | nbsp | linebreaks | safe}}
           {%endautoescape %}
-          {% if dynamic_file_contents %}
-          <h3>Dynamic Simulation Parameters</h3>
-          {% autoescape off %}
-          {{ dynamic_file_contents | nbsp | linebreaks | safe}}
-          {% endautoescape %}
-          {% endif %}
           <h3>Assumptions</h3>
           {%autoescape off %}
           {{ assump_file_contents | nbsp | linebreaks | safe}}


### PR DESCRIPTION
This PR:
- removes references to `dynamic_input_parameters`
- saves foreign key with `taxbrain_model.json_text.save()` (who knew all the ways you had to save a django relation?)
- use `set_fields` and `to_json` to create `raw_assumption_text` field if it is not there

@lucassz can you review this?