### PR TITLE
Load Redis client from existing environment variable

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -25,9 +25,9 @@ for information on how to set this up on your operating system.
     2. run
     ```
     export PB_VERSION='type current PolicyBrain version here'
-    docker build -t distributed:$PB_VERSION ./
-    docker build -t celery:$PB_VERSION --file Dockerfile.celery ./
-    docker build -t flask:$PB_VERSION --file Dockerfile.flask
+    docker build -t opensourcepolicycenter/distributed:$PB_VERSION ./
+    docker build -t opensourcepolicycenter/celery:$PB_VERSION --build-arg TAG=$PB_VERSION --file Dockerfile.celery ./
+    docker build -t opensourcepolicycenter/flask:$PB_VERSION --build-arg TAG=$PB_VERSION --file Dockerfile.flask ./
     ```
 3. Depending on your system you may have to tweak the Docker memory and CPU
 usage limits. I find that I can do most runs with RAM set around 8 GB and

--- a/distributed/api/endpoints.py
+++ b/distributed/api/endpoints.py
@@ -13,7 +13,8 @@ from api.celery_tasks import (dropq_task_async,
 bp = Blueprint('endpoints', __name__)
 
 queue_name = "celery"
-client = redis.StrictRedis(host="redis", port=6379)
+client = redis.StrictRedis.from_url(os.environ.get("CELERY_BROKER_URL",
+                                                   "redis://redis:6379/0"))
 
 
 def dropq_endpoint(dropq_task):


### PR DESCRIPTION
Load Redis client from existing environment variable instead of hardcoding an unchangeable hostname for it. Necessary for #913 in an auxiliary way, and seems like a good practice. It's not totally clear to me what the distinction between `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND` (which we set to the same value in practice) is, so do let me know if it should be the other one.