### PR TITLE
 Beginning steps for refactoring high level submission logic (retry of #894)

### DIFF
--- a/webapp/apps/conftest.py
+++ b/webapp/apps/conftest.py
@@ -9,31 +9,7 @@ CUR_PATH = os.path.join(
 )
 
 
-def set_fixture_prop(func):
-    """
-    Decorator for py.test fixtures that sets a class property if it is called
-    by a class. This is required because you cannot pass py.test fixtures as
-    arguments for class methods
-
-    py.test fixture in class:
-    https://docs.pytest.org/en/latest/unittest.html
-
-    py.test access args for decorated function:
-    https://github.com/pytest-dev/pytest/issues/2782
-    """
-    @functools.wraps(func)
-    def wrapper(request):
-        res = func(request)
-        if request.cls:
-            setattr(request.cls, request.fixturename, res)
-
-        return res
-
-    return wrapper
-
-
 @pytest.fixture()
-@set_fixture_prop
 def r1(request):
     with open(os.path.join(CUR_PATH, 'r1.json')) as f:
         return f.read()
@@ -46,14 +22,12 @@ def regression_sample_reform():
 
 
 @pytest.fixture()
-@set_fixture_prop
 def bad_reform(request):
     with open(os.path.join(CUR_PATH, 'bad_reform.json')) as f:
         return f.read()
 
 
 @pytest.fixture()
-@set_fixture_prop
 def warning_reform(request):
     with open(os.path.join(CUR_PATH, 'warning_reform.json')) as f:
         return f.read()
@@ -94,7 +68,6 @@ def fields_base():
 
 
 @pytest.fixture()
-@set_fixture_prop
 def test_coverage_gui_fields(request):
     _test_coverage_gui_fields = {
         'cpi_offset': ['<', -0.0025],
@@ -111,7 +84,6 @@ def test_coverage_gui_fields(request):
 
 
 @pytest.fixture()
-@set_fixture_prop
 def test_coverage_fields(request):
     # quick work-around to get set_fixture_prop decorator to work with
     # fixture as argument
@@ -126,7 +98,6 @@ def test_coverage_fields(request):
 
 
 @pytest.fixture()
-@set_fixture_prop
 def test_coverage_behavioral_gui_fields(request):
     _test_coverage_behavoiral_gui_fields = {
         'BE_sub': [1.0],
@@ -137,7 +108,6 @@ def test_coverage_behavioral_gui_fields(request):
 
 
 @pytest.fixture()
-@set_fixture_prop
 def test_coverage_behavioral_fields(request):
     # quick work-around to get set_fixture_prop decorator to work with
     # fixture as argument
@@ -336,7 +306,6 @@ def exp_errors_warnings_policy_behavior():
 
 
 @pytest.fixture()
-@set_fixture_prop
 def assumptions_text(request):
     with open(os.path.join(CUR_PATH, 'assumptions_text.txt')) as f:
         return f.read()
@@ -393,7 +362,6 @@ def errors_warnings_exp_read_json_assumptions():
 
 
 @pytest.fixture()
-@set_fixture_prop
 def skelaton_res_lt_0130(request):
     _path = os.path.join(CUR_PATH, "skelaton_res_lt_0130.json")
     with open(_path) as js:
@@ -401,7 +369,6 @@ def skelaton_res_lt_0130(request):
 
 
 @pytest.fixture()
-@set_fixture_prop
 def skelaton_res_gt_0130(request):
     _path = os.path.join(CUR_PATH, "skelaton_res_gt_0130.json")
     with open(_path) as js:

--- a/webapp/apps/constants.py
+++ b/webapp/apps/constants.py
@@ -1,5 +1,7 @@
 import os
+import taxcalc
 
+from django.conf import settings
 from django.utils.safestring import mark_safe
 
 DISTRIBUTION_TOOLTIP = "Key variables in the computation of tax liabilities."
@@ -45,3 +47,8 @@ OUT_OF_RANGE_ERROR_MSG = mark_safe("""
     &emsp;- If the field has an error message, then the parameter value must be
     changed so that it is in a valid range.
 </div>""")
+
+
+WEBAPP_VERSION = settings.WEBAPP_VERSION
+tcversion_info = taxcalc._version.get_versions()
+TAXCALC_VERSION = tcversion_info['version']

--- a/webapp/apps/dynamic/tests/test_behavioral.py
+++ b/webapp/apps/dynamic/tests/test_behavioral.py
@@ -17,7 +17,6 @@ from ..forms import DynamicBehavioralInputsModelForm
 CLIENT = Client()
 
 
-@pytest.mark.usefixtures("r1")
 @pytest.mark.django_db
 class TestDynamicBehavioralViews(object):
     ''' Test the partial equilibrium dynamic views of this app. '''
@@ -110,9 +109,9 @@ class TestDynamicBehavioralViews(object):
         assert user_mods["behavior"][2016]["_BE_sub"][0] == 0.25
         assert last_posted['use_puf_not_cps'] is False
 
-    def test_behavioral_reform_from_file(self):
+    def test_behavioral_reform_from_file(self, r1):
         # Do the microsim from file
-        data = get_file_post_data(START_YEAR, self.r1)
+        data = get_file_post_data(START_YEAR, r1)
         micro1 = do_micro_sim(CLIENT, data, post_url='/taxbrain/file/')
         micro1 = micro1["response"]
 

--- a/webapp/apps/dynamic/tests/test_models.py
+++ b/webapp/apps/dynamic/tests/test_models.py
@@ -1,5 +1,3 @@
-from django.test import TestCase
-
 from ...test_assets.test_models import (TaxBrainTableResults,
                                         TaxBrainFieldsTest)
 
@@ -7,31 +5,41 @@ from ...dynamic.models import DynamicBehaviorOutputUrl
 from ...dynamic.forms import DynamicBehavioralInputsModelForm
 
 
-class TaxBrainDynamicResultsTest(TaxBrainTableResults, TestCase):
+class TestTaxBrainDynamicResults(TaxBrainTableResults):
 
-    def test_dynamic_tc_lt_0130(self):
-        self.tc_lt_0130(self.test_coverage_behavioral_fields,
-                        Form=DynamicBehavioralInputsModelForm,
-                        UrlModel=DynamicBehaviorOutputUrl)
+    def test_dynamic_tc_lt_0130(self, test_coverage_behavioral_fields,
+                                skelaton_res_lt_0130, skelaton_res_gt_0130):
+        self.tc_table_backcompat(test_coverage_behavioral_fields,
+                                 skelaton_res_lt_0130,
+                                 skelaton_res_gt_0130,
+                                 Form=DynamicBehavioralInputsModelForm,
+                                 UrlModel=DynamicBehaviorOutputUrl,
+                                 taxcalc_vers="0.10.2.abc",
+                                 webapp_vers="1.1.1")
 
-    def test_dynamic_tc_gt_0130(self):
-        self.tc_gt_0130(self.test_coverage_behavioral_fields,
-                        Form=DynamicBehavioralInputsModelForm,
-                        UrlModel=DynamicBehaviorOutputUrl)
+    def test_dynamic_tc_gt_0130(self, test_coverage_behavioral_fields,
+                               skelaton_res_gt_0130):
+        self.tc_table_backcompat(test_coverage_behavioral_fields,
+                                 skelaton_res_gt_0130,
+                                 skelaton_res_gt_0130,
+                                 Form=DynamicBehavioralInputsModelForm,
+                                 UrlModel=DynamicBehaviorOutputUrl,
+                                 taxcalc_vers="0.13.0",
+                                 webapp_vers="1.2.0")
 
 
-class TaxBrainDynamicFieldsTest(TaxBrainFieldsTest, TestCase):
+class TestTaxBrainDynamicFields(TaxBrainFieldsTest):
 
-    def test_set_fields(self):
+    def test_set_fields(self, test_coverage_behavioral_gui_fields):
         start_year = 2017
-        fields = self.test_coverage_behavioral_gui_fields.copy()
+        fields = test_coverage_behavioral_gui_fields.copy()
         fields['first_year'] = start_year
         self.parse_fields(start_year, fields,
                           Form=DynamicBehavioralInputsModelForm)
 
-    def test_data_source_puf(self):
+    def test_data_source_puf(self, test_coverage_behavioral_gui_fields):
         start_year = 2017
-        fields = self.test_coverage_behavioral_gui_fields.copy()
+        fields = test_coverage_behavioral_gui_fields.copy()
         fields['first_year'] = start_year
         fields['data_source'] = 'PUF'
         model = self.parse_fields(start_year, fields,
@@ -40,9 +48,9 @@ class TaxBrainDynamicFieldsTest(TaxBrainFieldsTest, TestCase):
 
         assert model.use_puf_not_cps
 
-    def test_get_model_specs_with_errors(self):
+    def test_get_model_specs_with_errors(self, test_coverage_behavioral_gui_fields):
         start_year = 2017
-        fields = self.test_coverage_behavioral_gui_fields.copy()
+        fields = test_coverage_behavioral_gui_fields.copy()
         fields['BE_sub'] = [-0.8]
         fields['BE_inc'] = [0.2]
         fields['first_year'] = start_year

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -24,15 +24,15 @@ from .models import (DynamicSaveInputs, DynamicOutputUrl,
 from ..taxbrain.models import (TaxSaveInputs, OutputUrl,
                                ErrorMessageTaxCalculator,
                                JSONReformTaxCalculator)
-from ..taxbrain.views import (make_bool, dropq_compute,
-                              JOB_PROC_TIME_IN_SECONDS,
-                              add_summary_column, get_result_context)
+from ..taxbrain.views import (dropq_compute, add_summary_column,
+                              get_result_context)
 from ..taxbrain.param_formatters import (to_json_reform, get_reform_from_gui,
                                          parse_fields, append_errors_warnings)
-from ..taxbrain.helpers import (taxcalc_results_to_tables,
+from ..taxbrain.helpers import (taxcalc_results_to_tables, make_bool,
                                 convert_val, json_int_key_encode)
 from ..taxbrain.param_displayers import default_behavior
 from ..taxbrain.compute import JobFailError, WORKER_HN
+from ..taxbrain.submit_data import JOB_PROC_TIME_IN_SECONDS
 from .helpers import (default_parameters, job_submitted,
                       ogusa_results_to_tables, success_text,
                       failure_text, strip_empty_lists,

--- a/webapp/apps/taxbrain/submit_data.py
+++ b/webapp/apps/taxbrain/submit_data.py
@@ -1,4 +1,21 @@
 from collections import namedtuple
+import datetime
+import json
+
+from django.utils import timezone
+from ipware.ip import get_real_ip
+from django.http import HttpResponse
+from django.contrib.auth.models import User
+
+from .models import TaxSaveInputs, JSONReformTaxCalculator, OutputUrl
+from .compute import NUM_BUDGET_YEARS, NUM_BUDGET_YEARS_QUICK
+from .forms import TaxBrainForm
+from .helpers import make_bool, json_int_key_encode
+from .param_formatters import get_reform_from_file, append_errors_warnings
+from ..constants import (START_YEAR, OUT_OF_RANGE_ERROR_MSG,
+                         WEBAPP_VERSION, TAXCALC_VERSION)
+
+JOB_PROC_TIME_IN_SECONDS = 35
 
 PostMeta = namedtuple(
     'PostMeta',
@@ -24,3 +41,286 @@ PostMeta = namedtuple(
 )
 
 BadPost = namedtuple('BadPost', ['http_response_404', 'has_errors'])
+
+
+def process_reform(request, dropq_compute, user=None, **kwargs):
+    """
+    Submits TaxBrain reforms.  This handles data from the GUI interface
+    and the file input interface.  With some tweaks this model could be used
+    to submit reforms for all PolicyBrain models
+
+    returns OutputUrl object with parsed user input and warning/error messages
+            if necessary
+            boolean variable indicating whether this reform has errors or not
+    """
+    post_meta = submit_reform(request, dropq_compute, user=user, **kwargs)
+    if isinstance(post_meta, BadPost) or post_meta.stop_submission:
+        return None, post_meta
+        # (args['personal_inputs'], args['json_reform'], args['has_errors'],
+        #  errors_warnings)
+    else:
+        url = save_model(post_meta)
+        return url, post_meta
+
+
+def save_model(post_meta):
+    """
+    Save user input data
+    returns OutputUrl object
+    """
+    model = post_meta.model
+    # create model for file_input case
+    if model is None:
+        model = TaxSaveInputs()
+    model.job_ids = post_meta.submitted_ids
+    model.json_text = post_meta.json_reform
+    model.first_year = int(post_meta.start_year)
+    model.data_source = post_meta.data_source
+    model.quick_calc = not post_meta.do_full_calc
+    model.save()
+
+    # create OutputUrl object
+    if post_meta.url is None:
+        unique_url = OutputUrl()
+    else:
+        unique_url = post_meta.url
+    if post_meta.user:
+        unique_url.user = post_meta.user
+    elif post_meta.request and post_meta.request.user.is_authenticated():
+        current_user = User.objects.get(pk=post_meta.request.user.id)
+        unique_url.user = current_user
+
+    if unique_url.taxcalc_vers is None:
+        unique_url.taxcalc_vers = TAXCALC_VERSION
+    if unique_url.webapp_vers is None:
+        unique_url.webapp_vers = WEBAPP_VERSION
+
+    unique_url.unique_inputs = model
+    unique_url.model_pk = model.pk
+    cur_dt = timezone.now()
+    future_offset_seconds = ((2 + post_meta.max_q_length) *
+                             JOB_PROC_TIME_IN_SECONDS)
+    future_offset = datetime.timedelta(seconds=future_offset_seconds)
+    expected_completion = cur_dt + future_offset
+    unique_url.exp_comp_datetime = expected_completion
+    unique_url.save()
+
+    return unique_url
+
+
+def submit_reform(request, dropq_compute, user=None, json_reform_id=None):
+    """
+    Parses user input data and submits reform
+
+    returns dictionary of arguments intended to be inputs for `save_model`
+    """
+    fields = dict(request.GET)
+    fields.update(dict(request.POST))
+    fields = {k: v[0] if isinstance(v, list) else v
+              for k, v in list(fields.items())}
+    start_year = fields.get('start_year', START_YEAR)
+    # TODO: migrate first_year to start_year to get rid of weird stuff like
+    # this
+    fields['first_year'] = fields['start_year']
+    has_errors = make_bool(fields['has_errors'])
+
+    # get files from the request object
+    request_files = request.FILES
+
+    # which file to use, front-end not yet implemented
+    data_source = fields.get('data_source', 'PUF')
+    use_puf_not_cps = (data_source == 'PUF')
+
+    # declare a bunch of variables--TODO: clean this up
+    taxcalc_errors = False
+    taxcalc_warnings = False
+    is_valid = True
+    has_parse_errors = False
+    _ew = {'warnings': {}, 'errors': {}}
+    errors_warnings = {'policy': _ew.copy(), 'behavior': _ew.copy()}
+    reform_dict = {}
+    assumptions_dict = {}
+    reform_text = ""
+    assumptions_text = ""
+    personal_inputs = None
+    model = None
+    is_file = False
+    submitted_ids = None
+    max_q_length = None
+    # Assume we do the full calculation unless we find out otherwise
+    do_full_calc = False if fields.get('quick_calc') else True
+    if do_full_calc and 'full_calc' in fields:
+        del fields['full_calc']
+    elif 'quick_calc' in fields:
+        del fields['quick_calc']
+
+    # re-submission of file for case where file-input generated warnings
+    if json_reform_id:
+        try:
+            json_reform = JSONReformTaxCalculator.objects.get(
+                id=int(json_reform_id)
+            )
+        except Exception:
+            msg = "ID {} is not in JSON reform database".format(json_reform_id)
+            return BadPost(
+                http_response_404=HttpResponse(msg, status=400),
+                has_errors=True
+            )
+        reform_dict = json_int_key_encode(json.loads(json_reform.reform_text))
+        assumptions_dict = json_int_key_encode(
+            json.loads(json_reform.assumption_text))
+        reform_text = json_reform.raw_reform_text
+        assumptions_text = json_reform.raw_assumption_text
+        errors_warnings = json_reform.get_errors_warnings()
+
+        if "docfile" in request_files or "assumpfile" in request_files:
+            if "docfile" in request_files or len(reform_text) == 0:
+                reform_text = None
+            if "assumpfile" in request_files or len(assumptions_text) == 0:
+                assumptions_text = None
+
+            (reform_dict, assumptions_dict, reform_text, assumptions_text,
+                errors_warnings) = get_reform_from_file(request_files,
+                                                        reform_text,
+                                                        assumptions_text)
+
+            json_reform.reform_text = json.dumps(reform_dict)
+            json_reform.assumption_text = json.dumps(assumptions_dict)
+            json_reform.raw_reform_text = reform_text
+            json_reform.raw_assumption_text = assumptions_text
+            json_reform.errors_warnings_text = json.dumps(errors_warnings)
+            json_reform.save()
+
+            has_errors = False
+
+    else:  # fresh file upload or GUI run
+        if 'docfile' in request_files:
+            is_file = True
+            (reform_dict, assumptions_dict, reform_text, assumptions_text,
+                errors_warnings) = get_reform_from_file(request_files)
+        else:
+            personal_inputs = TaxBrainForm(start_year, use_puf_not_cps, fields)
+            # If an attempt is made to post data we don't accept
+            # raise a 400
+            if personal_inputs.non_field_errors():
+                return BadPost(
+                    http_response_404=HttpResponse(
+                        "Bad Input!", status=400
+                    ),
+                    has_errors=True
+                )
+            is_valid = personal_inputs.is_valid()
+            if is_valid:
+                model = personal_inputs.save(commit=False)
+                model.set_fields()
+                model.save()
+                (reform_dict, assumptions_dict, reform_text, assumptions_text,
+                    errors_warnings) = model.get_model_specs()
+        json_reform = JSONReformTaxCalculator(
+            reform_text=json.dumps(reform_dict),
+            assumption_text=json.dumps(assumptions_dict),
+            raw_reform_text=reform_text,
+            raw_assumption_text=assumptions_text,
+            errors_warnings_text=json.dumps(errors_warnings)
+        )
+        json_reform.save()
+
+    # TODO: account for errors
+    # 5 cases:
+    #   0. no warning/error messages --> run model
+    #   1. has seen warning/error messages and now there are no errors
+    #        --> run model
+    #   2. has not seen warning/error messages --> show warning/error messages
+    #   3. has seen warning/error messages and there are still error messages
+    #        --> show warning/error messages again
+    #   4. no user input --> do not run model
+
+    # We need to stop on both! File uploads should stop if there are 'behavior'
+    # or 'policy' errors
+    warn_msgs = any(len(errors_warnings[project]['warnings']) > 0
+                    for project in ['policy', 'behavior'])
+    error_msgs = any(len(errors_warnings[project]['errors']) > 0
+                     for project in ['policy', 'behavior'])
+    stop_errors = not is_valid or error_msgs
+    stop_submission = stop_errors or (not has_errors and warn_msgs)
+    if stop_submission:
+        taxcalc_errors = bool(error_msgs)
+        taxcalc_warnings = bool(warn_msgs)
+        if personal_inputs is not None:
+            # ensure that parameters causing the warnings are shown on page
+            # with warnings/errors
+            personal_inputs = TaxBrainForm(
+                start_year,
+                use_puf_not_cps,
+                initial=json.loads(personal_inputs.data['raw_input_fields'])
+            )
+            # TODO: parse warnings for file_input
+            # only handle GUI errors for now
+            if ((taxcalc_errors or taxcalc_warnings) and
+                    personal_inputs is not None):
+                # we are only concerned with adding *static* reform errors to
+                # the *static* reform page.
+                append_errors_warnings(
+                    errors_warnings['policy'],
+                    lambda param, msg: personal_inputs.add_error(param, msg)
+                )
+            has_parse_errors = any('Unrecognize value' in e[0]
+                                   for e
+                                   in list(personal_inputs.errors.values()))
+            if taxcalc_warnings or taxcalc_errors:
+                personal_inputs.add_error(None, OUT_OF_RANGE_ERROR_MSG)
+            if has_parse_errors:
+                msg = ("Some fields have unrecognized values. Enter comma "
+                       "separated values for each input.")
+                personal_inputs.add_error(None, msg)
+    else:
+        log_ip(request)
+        user_mods = dict({'policy': reform_dict}, **assumptions_dict)
+        data = {'user_mods': user_mods,
+                'first_budget_year': int(start_year),
+                'use_puf_not_cps': use_puf_not_cps}
+        if do_full_calc:
+            data_list = [dict(year=i, **data) for i in range(NUM_BUDGET_YEARS)]
+            submitted_ids, max_q_length = (
+                dropq_compute.submit_calculation(data_list))
+        else:
+            data_list = [dict(year=i, **data)
+                         for i in range(NUM_BUDGET_YEARS_QUICK)]
+            submitted_ids, max_q_length = (
+                dropq_compute.submit_quick_calculation(data_list))
+
+    return PostMeta(
+        request=request,
+        personal_inputs=personal_inputs,
+        json_reform=json_reform,
+        model=model,
+        stop_submission=stop_submission,
+        has_errors=any([taxcalc_errors, taxcalc_warnings,
+                        not is_valid]),
+        errors_warnings=errors_warnings,
+        start_year=start_year,
+        data_source=data_source,
+        do_full_calc=do_full_calc,
+        is_file=is_file,
+        reform_dict=reform_dict,
+        assumptions_dict=assumptions_dict,
+        reform_text=reform_text,
+        assumptions_text=assumptions_text,
+        submitted_ids=submitted_ids,
+        max_q_length=max_q_length,
+        user=user,
+        url=None
+    )
+
+
+def log_ip(request):
+    """
+    Attempt to get the IP address of this request and log it
+    """
+    ip = get_real_ip(request)
+    if ip is not None:
+        # we have a real, public ip address for user
+        print("BEGIN DROPQ WORK FROM: ", ip)
+    else:
+        # we don't have a real, public ip address for user
+        print("BEGIN DROPQ WORK FROM: unknown IP")

--- a/webapp/apps/taxbrain/submit_data.py
+++ b/webapp/apps/taxbrain/submit_data.py
@@ -49,9 +49,11 @@ def process_reform(request, dropq_compute, user=None, **kwargs):
     and the file input interface.  With some tweaks this model could be used
     to submit reforms for all PolicyBrain models
 
-    returns OutputUrl object with parsed user input and warning/error messages
-            if necessary
-            boolean variable indicating whether this reform has errors or not
+    returns:
+    - url: OutputUrl object with parsed user input and warning/error
+        messages if necessary
+    - post_meta: namedtuple containing data relevant to the parameter
+        submission
     """
     post_meta = submit_reform(request, dropq_compute, user=user, **kwargs)
     if isinstance(post_meta, BadPost) or post_meta.stop_submission:

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -23,8 +23,6 @@ NUM_BUDGET_YEARS = int(os.environ.get("NUM_BUDGET_YEARS", "10"))
 START_YEAR = 2016
 
 
-@pytest.mark.usefixtures("r1", "assumptions_text", "warning_reform",
-                         "bad_reform", "test_coverage_fields")
 @pytest.mark.django_db
 class TestTaxBrainViews(object):
     ''' Test the views of this app. '''
@@ -117,12 +115,12 @@ class TestTaxBrainViews(object):
                             str(START_YEAR), data_source=data_source)
 
     @pytest.mark.parametrize('data_source', ['PUF', 'CPS'])
-    def test_taxbrain_file_post_quick_calc(self, data_source):
+    def test_taxbrain_file_post_quick_calc(self, data_source, r1):
         """
         Using file-upload interface, test quick calculation post and full
         post from quick_calc page
         """
-        data = get_file_post_data(START_YEAR, self.r1, quick_calc=False)
+        data = get_file_post_data(START_YEAR, r1, quick_calc=False)
         data.pop('data_source')
         data.pop('start_year')
         wnc, created = WorkerNodesCounter.objects.get_or_create(
@@ -148,7 +146,7 @@ class TestTaxBrainViews(object):
 
         # Check that data was saved properly
         truth_mods = taxcalc.Calculator.read_json_param_objects(
-            self.r1,
+            r1,
             None,
         )
         truth_mods = truth_mods["policy"]
@@ -507,13 +505,14 @@ class TestTaxBrainViews(object):
         'data_source,use_assumptions',
         [('PUF', True), ('CPS', False)]
     )
-    def test_taxbrain_post_file(self, data_source, use_assumptions):
+    def test_taxbrain_post_file(self, data_source, use_assumptions,
+                                assumptions_text, r1):
         if use_assumptions:
-            assumptions_text = self.assumptions_text
+            assumptions_text = assumptions_text
         else:
             assumptions_text = None
         data = get_file_post_data(START_YEAR,
-                                  self.r1,
+                                  r1,
                                   assumptions_text)
         data.pop('start_year')
         data.pop('data_source')
@@ -527,11 +526,11 @@ class TestTaxBrainViews(object):
                             str(START_YEAR), data_source=data_source)
 
     @pytest.mark.xfail
-    def test_taxbrain_view_old_data_model(self):
+    def test_taxbrain_view_old_data_model(self, test_coverage_fields):
         # Monkey patch to mock out running of compute jobs
         get_dropq_compute_from_module('webapp.apps.taxbrain.views')
 
-        unique_url = get_taxbrain_model(self.test_coverage_fields,
+        unique_url = get_taxbrain_model(test_coverage_fields,
                                         taxcalc_vers="0.10.0",
                                         webapp_vers="1.1.0")
 
@@ -569,7 +568,7 @@ class TestTaxBrainViews(object):
         assert response.context['has_errors'] is True
 
     @pytest.mark.parametrize('data_source', ['PUF', 'CPS'])
-    def test_taxbrain_error_reform_file(self, data_source):
+    def test_taxbrain_error_reform_file(self, data_source, bad_reform):
         """
         POST a reform file that causes errors. See PB issue #630
         """
@@ -578,7 +577,7 @@ class TestTaxBrainViews(object):
         # Monkey patch to mock out running of compute jobs
         get_dropq_compute_from_module('webapp.apps.taxbrain.views')
 
-        data = get_file_post_data(START_YEAR, self.bad_reform)
+        data = get_file_post_data(START_YEAR, bad_reform)
         data.pop('start_year')
         data.pop('data_source')
         url = '/taxbrain/file/?start_year={0}&data_source={1}'.format(
@@ -611,7 +610,7 @@ class TestTaxBrainViews(object):
         assert response.context['start_year'] == str(START_YEAR)
 
     @pytest.mark.parametrize('data_source', ['PUF', 'CPS'])
-    def test_taxbrain_warning_reform_file(self, data_source):
+    def test_taxbrain_warning_reform_file(self, data_source, warning_reform):
         """
         POST a reform file that causes warnings and check that re-submission
         is allowed. See PB issue #630 and #761
@@ -620,7 +619,7 @@ class TestTaxBrainViews(object):
         # Monkey patch to mock out running of compute jobs
         get_dropq_compute_from_module('webapp.apps.taxbrain.views')
 
-        data = get_file_post_data(START_YEAR, self.warning_reform)
+        data = get_file_post_data(START_YEAR, warning_reform)
         data.pop('start_year')
         data.pop('data_source')
         url = '/taxbrain/file/?start_year={0}&data_source={1}'.format(
@@ -662,7 +661,8 @@ class TestTaxBrainViews(object):
         [('PUF', True), ('CPS', False)]
     )
     def test_taxbrain_reform_file_file_swap(
-            self, data_source, use_assumptions):
+        self, data_source, use_assumptions, assumptions_text,
+        warning_reform, r1):
         """
         POST a reform file that causes warnings, swap files, and make sure
         swapped files are used. See PB issue #630 and #761
@@ -672,11 +672,11 @@ class TestTaxBrainViews(object):
         # Monkey patch to mock out running of compute jobs
         get_dropq_compute_from_module('webapp.apps.taxbrain.views')
         if use_assumptions:
-            assumptions_text = self.assumptions_text
+            assumptions_text = assumptions_text
         else:
             assumptions_text = None
 
-        data = get_file_post_data(start_year, self.warning_reform,
+        data = get_file_post_data(start_year, warning_reform,
                                   assumptions_text)
         data.pop('start_year')
         data.pop('data_source')
@@ -704,7 +704,7 @@ class TestTaxBrainViews(object):
             'has_errors': ['True'],
         }
         data_file = get_file_post_data(START_YEAR,
-                                       self.r1,
+                                       r1,
                                        assumptions_text)
         data2['docfile'] = data_file['docfile']
 
@@ -735,9 +735,9 @@ class TestTaxBrainViews(object):
         check_posted_params(result['tb_dropq_compute'], truth_mods,
                             str(start_year))
 
-    def test_taxbrain_file_up_to_2018(self):
+    def test_taxbrain_file_up_to_2018(self, r1):
         start_year = 2018
-        data = get_file_post_data(start_year, self.r1)
+        data = get_file_post_data(start_year, r1)
 
         post_url = '/taxbrain/file/'
 
@@ -749,7 +749,7 @@ class TestTaxBrainViews(object):
 
         # Check that data was saved properly
         truth_mods = taxcalc.Calculator.read_json_param_objects(
-            self.r1,
+            r1,
             None,
         )
         truth_mods = truth_mods["policy"]

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -9,24 +9,20 @@ from mock import Mock
 import sys
 
 import taxcalc
-import datetime
 from django.utils import timezone
 from urllib.parse import urlparse, parse_qs
-from ipware.ip import get_real_ip
 
 from django.contrib.auth.decorators import permission_required
-from django.http import (HttpResponseRedirect, HttpResponse, Http404,
-                         JsonResponse)
-from django.shortcuts import (render, render_to_response, get_object_or_404,
+from django.http import HttpResponse, Http404, JsonResponse
+from django.shortcuts import (render, render_to_response,
                               redirect)
 from django.template.context import RequestContext
-from django.contrib.auth.models import User
 
 from .forms import TaxBrainForm
 from .models import (TaxSaveInputs, OutputUrl, JSONReformTaxCalculator,
                      ErrorMessageTaxCalculator)
 from .helpers import (taxcalc_results_to_tables, format_csv,
-                      json_int_key_encode, make_bool)
+                      json_int_key_encode)
 from .param_displayers import nested_form_parameters
 from .compute import (DropqCompute, MockCompute, JobFailError,
                       NUM_BUDGET_YEARS, NUM_BUDGET_YEARS_QUICK, WORKER_HN)
@@ -36,14 +32,12 @@ from ..constants import (DISTRIBUTION_TOOLTIP, DIFFERENCE_TOOLTIP,
                          REFORM_TOOLTIP, FISCAL_CURRENT_LAW, FISCAL_REFORM,
                          FISCAL_CHANGE, INCOME_BINS_TOOLTIP,
                          INCOME_DECILES_TOOLTIP, START_YEAR, START_YEARS,
-                         DATA_SOURCES, DEFAULT_SOURCE, OUT_OF_RANGE_ERROR_MSG)
+                         DATA_SOURCES, DEFAULT_SOURCE, OUT_OF_RANGE_ERROR_MSG,
+                         WEBAPP_VERSION, TAXCALC_VERSION)
 
 from ..formatters import get_version
-from .param_formatters import (get_reform_from_file, get_reform_from_gui,
-                               to_json_reform, append_errors_warnings)
-from .submit_data import PostMeta, BadPost
-
-from django.conf import settings
+from .param_formatters import (to_json_reform, append_errors_warnings)
+from .submit_data import PostMeta, BadPost, process_reform, save_model, log_ip
 
 # Mock some module for imports because we can't fit them on Heroku slugs
 MOCK_MODULES = ['matplotlib', 'matplotlib.pyplot', 'mpl_toolkits',
@@ -52,297 +46,6 @@ ENABLE_QUICK_CALC = bool(os.environ.get('ENABLE_QUICK_CALC', ''))
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 dropq_compute = DropqCompute()
-
-WEBAPP_VERSION = settings.WEBAPP_VERSION
-
-tcversion_info = taxcalc._version.get_versions()
-
-TAXCALC_VERSION = tcversion_info['version']
-
-JOB_PROC_TIME_IN_SECONDS = 35
-
-
-def log_ip(request):
-    """
-    Attempt to get the IP address of this request and log it
-    """
-    ip = get_real_ip(request)
-    if ip is not None:
-        # we have a real, public ip address for user
-        print("BEGIN DROPQ WORK FROM: ", ip)
-    else:
-        # we don't have a real, public ip address for user
-        print("BEGIN DROPQ WORK FROM: unknown IP")
-
-
-def save_model(post_meta):
-    """
-    Save user input data
-    returns OutputUrl object
-    """
-    model = post_meta.model
-    # create model for file_input case
-    if model is None:
-        model = TaxSaveInputs()
-    model.job_ids = post_meta.submitted_ids
-    model.json_text = post_meta.json_reform
-    model.first_year = int(post_meta.start_year)
-    model.data_source = post_meta.data_source
-    model.quick_calc = not post_meta.do_full_calc
-    model.save()
-
-    # create OutputUrl object
-    if post_meta.url is None:
-        unique_url = OutputUrl()
-    else:
-        unique_url = post_meta.url
-    if post_meta.user:
-        unique_url.user = post_meta.user
-    elif post_meta.request and post_meta.request.user.is_authenticated():
-        current_user = User.objects.get(pk=post_meta.request.user.id)
-        unique_url.user = current_user
-
-    if unique_url.taxcalc_vers is None:
-        unique_url.taxcalc_vers = TAXCALC_VERSION
-    if unique_url.webapp_vers is None:
-        unique_url.webapp_vers = WEBAPP_VERSION
-
-    unique_url.unique_inputs = model
-    unique_url.model_pk = model.pk
-    cur_dt = timezone.now()
-    future_offset_seconds = ((2 + post_meta.max_q_length) *
-                             JOB_PROC_TIME_IN_SECONDS)
-    future_offset = datetime.timedelta(seconds=future_offset_seconds)
-    expected_completion = cur_dt + future_offset
-    unique_url.exp_comp_datetime = expected_completion
-    unique_url.save()
-
-    return unique_url
-
-
-def submit_reform(request, user=None, json_reform_id=None):
-    """
-    Parses user input data and submits reform
-
-    returns dictionary of arguments intended to be inputs for `save_model`
-    """
-    fields = dict(request.GET)
-    fields.update(dict(request.POST))
-    fields = {k: v[0] if isinstance(v, list) else v
-              for k, v in list(fields.items())}
-    start_year = fields.get('start_year', START_YEAR)
-    # TODO: migrate first_year to start_year to get rid of weird stuff like
-    # this
-    fields['first_year'] = fields['start_year']
-    has_errors = make_bool(fields['has_errors'])
-
-    # get files from the request object
-    request_files = request.FILES
-
-    # which file to use, front-end not yet implemented
-    data_source = fields.get('data_source', 'PUF')
-    use_puf_not_cps = (data_source == 'PUF')
-
-    # declare a bunch of variables--TODO: clean this up
-    taxcalc_errors = False
-    taxcalc_warnings = False
-    is_valid = True
-    has_parse_errors = False
-    _ew = {'warnings': {}, 'errors': {}}
-    errors_warnings = {'policy': _ew.copy(), 'behavior': _ew.copy()}
-    reform_dict = {}
-    assumptions_dict = {}
-    reform_text = ""
-    assumptions_text = ""
-    personal_inputs = None
-    model = None
-    is_file = False
-    submitted_ids = None
-    max_q_length = None
-    # Assume we do the full calculation unless we find out otherwise
-    do_full_calc = False if fields.get('quick_calc') else True
-    if do_full_calc and 'full_calc' in fields:
-        del fields['full_calc']
-    elif 'quick_calc' in fields:
-        del fields['quick_calc']
-
-    # re-submission of file for case where file-input generated warnings
-    if json_reform_id:
-        try:
-            json_reform = JSONReformTaxCalculator.objects.get(
-                id=int(json_reform_id)
-            )
-        except Exception:
-            msg = "ID {} is not in JSON reform database".format(json_reform_id)
-            return BadPost(
-                http_response_404=HttpResponse(msg, status=400),
-                has_errors=True
-            )
-        reform_dict = json_int_key_encode(json.loads(json_reform.reform_text))
-        assumptions_dict = json_int_key_encode(
-            json.loads(json_reform.assumption_text))
-        reform_text = json_reform.raw_reform_text
-        assumptions_text = json_reform.raw_assumption_text
-        errors_warnings = json_reform.get_errors_warnings()
-
-        if "docfile" in request_files or "assumpfile" in request_files:
-            if "docfile" in request_files or len(reform_text) == 0:
-                reform_text = None
-            if "assumpfile" in request_files or len(assumptions_text) == 0:
-                assumptions_text = None
-
-            (reform_dict, assumptions_dict, reform_text, assumptions_text,
-                errors_warnings) = get_reform_from_file(request_files,
-                                                        reform_text,
-                                                        assumptions_text)
-
-            json_reform.reform_text = json.dumps(reform_dict)
-            json_reform.assumption_text = json.dumps(assumptions_dict)
-            json_reform.raw_reform_text = reform_text
-            json_reform.raw_assumption_text = assumptions_text
-            json_reform.errors_warnings_text = json.dumps(errors_warnings)
-            json_reform.save()
-
-            has_errors = False
-
-    else:  # fresh file upload or GUI run
-        if 'docfile' in request_files:
-            is_file = True
-            (reform_dict, assumptions_dict, reform_text, assumptions_text,
-                errors_warnings) = get_reform_from_file(request_files)
-        else:
-            personal_inputs = TaxBrainForm(start_year, use_puf_not_cps, fields)
-            # If an attempt is made to post data we don't accept
-            # raise a 400
-            if personal_inputs.non_field_errors():
-                return BadPost(
-                    http_response_404=HttpResponse(
-                        "Bad Input!", status=400
-                    ),
-                    has_errors=True
-                )
-            is_valid = personal_inputs.is_valid()
-            if is_valid:
-                model = personal_inputs.save(commit=False)
-                model.set_fields()
-                model.save()
-                (reform_dict, assumptions_dict, reform_text, assumptions_text,
-                    errors_warnings) = model.get_model_specs()
-        json_reform = JSONReformTaxCalculator(
-            reform_text=json.dumps(reform_dict),
-            assumption_text=json.dumps(assumptions_dict),
-            raw_reform_text=reform_text,
-            raw_assumption_text=assumptions_text,
-            errors_warnings_text=json.dumps(errors_warnings)
-        )
-        json_reform.save()
-
-    # TODO: account for errors
-    # 5 cases:
-    #   0. no warning/error messages --> run model
-    #   1. has seen warning/error messages and now there are no errors
-    #        --> run model
-    #   2. has not seen warning/error messages --> show warning/error messages
-    #   3. has seen warning/error messages and there are still error messages
-    #        --> show warning/error messages again
-    #   4. no user input --> do not run model
-
-    # We need to stop on both! File uploads should stop if there are 'behavior'
-    # or 'policy' errors
-    warn_msgs = any(len(errors_warnings[project]['warnings']) > 0
-                    for project in ['policy', 'behavior'])
-    error_msgs = any(len(errors_warnings[project]['errors']) > 0
-                     for project in ['policy', 'behavior'])
-    stop_errors = not is_valid or error_msgs
-    stop_submission = stop_errors or (not has_errors and warn_msgs)
-    if stop_submission:
-        taxcalc_errors = bool(error_msgs)
-        taxcalc_warnings = bool(warn_msgs)
-        if personal_inputs is not None:
-            # ensure that parameters causing the warnings are shown on page
-            # with warnings/errors
-            personal_inputs = TaxBrainForm(
-                start_year,
-                use_puf_not_cps,
-                initial=json.loads(personal_inputs.data['raw_input_fields'])
-            )
-            # TODO: parse warnings for file_input
-            # only handle GUI errors for now
-            if ((taxcalc_errors or taxcalc_warnings) and
-                    personal_inputs is not None):
-                # we are only concerned with adding *static* reform errors to
-                # the *static* reform page.
-                append_errors_warnings(
-                    errors_warnings['policy'],
-                    lambda param, msg: personal_inputs.add_error(param, msg)
-                )
-            has_parse_errors = any('Unrecognize value' in e[0]
-                                   for e
-                                   in list(personal_inputs.errors.values()))
-            if taxcalc_warnings or taxcalc_errors:
-                personal_inputs.add_error(None, OUT_OF_RANGE_ERROR_MSG)
-            if has_parse_errors:
-                msg = ("Some fields have unrecognized values. Enter comma "
-                       "separated values for each input.")
-                personal_inputs.add_error(None, msg)
-    else:
-        log_ip(request)
-        user_mods = dict({'policy': reform_dict}, **assumptions_dict)
-        data = {'user_mods': user_mods,
-                'first_budget_year': int(start_year),
-                'use_puf_not_cps': use_puf_not_cps}
-        if do_full_calc:
-            data_list = [dict(year=i, **data) for i in range(NUM_BUDGET_YEARS)]
-            submitted_ids, max_q_length = (
-                dropq_compute.submit_calculation(data_list))
-        else:
-            data_list = [dict(year=i, **data)
-                         for i in range(NUM_BUDGET_YEARS_QUICK)]
-            submitted_ids, max_q_length = (
-                dropq_compute.submit_quick_calculation(data_list))
-
-    return PostMeta(
-        request=request,
-        personal_inputs=personal_inputs,
-        json_reform=json_reform,
-        model=model,
-        stop_submission=stop_submission,
-        has_errors=any([taxcalc_errors, taxcalc_warnings,
-                        not is_valid]),
-        errors_warnings=errors_warnings,
-        start_year=start_year,
-        data_source=data_source,
-        do_full_calc=do_full_calc,
-        is_file=is_file,
-        reform_dict=reform_dict,
-        assumptions_dict=assumptions_dict,
-        reform_text=reform_text,
-        assumptions_text=assumptions_text,
-        submitted_ids=submitted_ids,
-        max_q_length=max_q_length,
-        user=user,
-        url=None
-    )
-
-
-def process_reform(request, user=None, **kwargs):
-    """
-    Submits TaxBrain reforms.  This handles data from the GUI interface
-    and the file input interface.  With some tweaks this model could be used
-    to submit reforms for all PolicyBrain models
-
-    returns OutputUrl object with parsed user input and warning/error messages
-            if necessary
-            boolean variable indicating whether this reform has errors or not
-    """
-    post_meta = submit_reform(request, user=user, **kwargs)
-    if isinstance(post_meta, BadPost) or post_meta.stop_submission:
-        return None, post_meta
-        # (args['personal_inputs'], args['json_reform'], args['has_errors'],
-        #  errors_warnings)
-    else:
-        url = save_model(post_meta)
-        return url, post_meta
 
 
 def file_input(request):
@@ -375,7 +78,8 @@ def file_input(request):
             errors = ["Please specify a tax-law change before submitting."]
             json_reform = None
         else:
-            obj, post_meta = process_reform(request, json_reform_id=form_id)
+            obj, post_meta = process_reform(request, dropq_compute,
+                                            json_reform_id=form_id)
             if isinstance(post_meta, BadPost):
                 return post_meta.http_response_404
             else:
@@ -436,7 +140,7 @@ def personal_results(request):
     if request.method == 'POST':
         print('method=POST get', request.GET)
         print('method=POST post', request.POST)
-        obj, post_meta = process_reform(request)
+        obj, post_meta = process_reform(request, dropq_compute)
         # case where validation failed in forms.TaxBrainForm
         # TODO: assert HttpResponse status is 404
         if isinstance(post_meta, BadPost):

--- a/webapp/apps/test_assets/test_models.py
+++ b/webapp/apps/test_assets/test_models.py
@@ -16,48 +16,31 @@ START_YEAR = 2016
 CURDIR = os.path.abspath(os.path.dirname(__file__))
 
 
-@pytest.mark.usefixtures("test_coverage_fields", "test_coverage_gui_fields",
-                         "test_coverage_behavioral_fields")
-class TaxBrainModelsTest:
-
-    def setUp(self):
-        pass
-
 
 @pytest.mark.usefixtures("skelaton_res_lt_0130",
                          "skelaton_res_gt_0130")
-class TaxBrainTableResults(TaxBrainModelsTest):
+@pytest.mark.django_db
+class TaxBrainTableResults(object):
 
-    def tc_lt_0130(self, fields, Form=TaxBrainForm, UrlModel=OutputUrl):
+    def tc_table_backcompat(self, fields, bef, aft, Form=TaxBrainForm,
+                            UrlModel=OutputUrl, taxcalc_vers="0.10.2.abc",
+                            webapp_vers="1.1.1"):
         unique_url = get_taxbrain_model(fields,
-                                        taxcalc_vers="0.10.2.abc",
-                                        webapp_vers="1.1.1",
+                                        taxcalc_vers=taxcalc_vers,
+                                        webapp_vers=webapp_vers,
                                         Form=Form, UrlModel=UrlModel)
 
         model = unique_url.unique_inputs
-        model.tax_result = self.skelaton_res_lt_0130
+        model.tax_result = bef
         model.creation_date = timezone.now()
         model.save()
 
         np.testing.assert_equal(model.get_tax_result(),
-                                self.skelaton_res_gt_0130)
-
-    def tc_gt_0130(self, fields, Form=TaxBrainForm, UrlModel=OutputUrl):
-        unique_url = get_taxbrain_model(fields,
-                                        taxcalc_vers="0.13.0",
-                                        webapp_vers="1.2.0",
-                                        Form=Form, UrlModel=UrlModel)
-
-        model = unique_url.unique_inputs
-        model.tax_result = self.skelaton_res_gt_0130
-        model.creation_date = timezone.now()
-        model.save()
-
-        np.testing.assert_equal(model.get_tax_result(),
-                                self.skelaton_res_gt_0130)
+                                aft)
 
 
-class TaxBrainFieldsTest(TaxBrainModelsTest):
+@pytest.mark.django_db
+class TaxBrainFieldsTest(object):
 
     def parse_fields(self, start_year, fields, Form=TaxBrainForm,
                      exp_result=None, use_puf_not_cps=True):


### PR DESCRIPTION
See #894: 

> The high level parameter submission logic is housed primarily in submit_reform. This is a complex function and does not have any unit tests. There are a fairly high number of paths that data can take through this function: File or GUI? Full calculation or quick calculation? Errors or no errors? If errors, were they detected in PolicyBrain or the upstream project? If errors, what type of errors and has the user seen them? On top of that, this function produces about 20 pieces of data.
> 
> The aim for this first PR is to:
> 1.  Move submit_reform into its own module. This makes the views.py module more pure in the sense that its functions map directly to web pages (i.e. a TaxBrain inputs page, an outputs page, an edit parameters page, etc.). This also modularizes the submission logic which will make it easier to apply to other apps in the future.
> 2. Add tests to pin down the behavior of submit_reform so that it can be changed safely in the future.

I am starting #894 with a clean slate given the extensive changes to code style and the `compute.py` architecture.
