### PR TITLE
In Python 3, '01' causes a syntax error when evaled via ast.literal_eval

### DIFF
--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -50,7 +50,8 @@ def is_safe(s):
     Returns:
         success: whether value is "safe" or not
     """
-    assert len(s) < 100
+    if len(s) > 100:
+        return False
     parsers = [VALUE, BOOL, REVERSE]
     tokens = s.split(',')
     success = [False] * len(tokens)

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -3,6 +3,7 @@ import pyparsing as pp
 import sys
 import six
 import re
+import ast
 
 # Mock some module for imports because we can't fit them on Heroku slugs
 import sys
@@ -30,18 +31,45 @@ FLOAT_LIT = pp.Word(pp.nums + '.')
 DEC_POINT = pp.Word('.', exact=1)
 FLOAT_LIT_FULL = pp.Word(pp.nums + '.' + pp.nums)
 COMMON = pp.Word(",", exact=1)
-REVERSE = pp.Word("<") + COMMON
-
+REVERSE = pp.Word("<")
 VALUE = WILDCARD | NEG_DASH | FLOAT_LIT_FULL | FLOAT_LIT | INT_LIT
-MORE_VALUES = COMMON + VALUE
-
 BOOL = WILDCARD | TRUE | FALSE
-MORE_BOOLS = COMMON + BOOL
-INPUT = (pp.Optional(REVERSE) +
-         BOOL +
-         pp.ZeroOrMore(MORE_BOOLS) | pp.Optional(REVERSE) +
-         VALUE +
-         pp.ZeroOrMore(MORE_VALUES))
+
+
+def is_safe(s):
+    """
+    Test if a string of comma-separated-values is "safe"
+    - is the string less than 100 characters?
+    - is the string boolean?
+    - is the string an integer or float?
+    - is the string a wildcard (*)?
+    - is the string a reverse character (<)?
+    If one of the tokens does not answer one of the above questions in the
+    affirmative, then it is deemed "not safe"
+
+    Returns:
+        success: whether value is "safe" or not
+    """
+    assert len(s) < 100
+    parsers = [VALUE, BOOL, REVERSE]
+    tokens = s.split(',')
+    success = [False] * len(tokens)
+    for i, token in enumerate(tokens):
+        token_strip = token.strip()
+        for parser in parsers:
+            try:
+                parser.parseString(token_strip)
+                if parser == VALUE:
+                    # make sure `ast.literal_eval` can parse
+                    # throws ValueError or SyntaxError on failure
+                    ast.literal_eval(token_strip)
+            except (pp.ParseException, ValueError, SyntaxError):
+                pass
+            else:
+                success[i] = True
+                break
+    return all(success)
+
 
 TRUE_REGEX = re.compile('(?i)true')
 FALSE_REGEX = re.compile('(?i)false')

--- a/webapp/apps/taxbrain/param_formatters.py
+++ b/webapp/apps/taxbrain/param_formatters.py
@@ -49,9 +49,8 @@ def parse_value(value, meta_param):
     # value is not an integer, float, or boolean string
     try:
         parsed = ast.literal_eval(prepped)
-    except ValueError:
-        return parsed
-
+    except (SyntaxError, ValueError):
+        return prepped
     # Use information given to us by upstream specs to convert this value
     # into desired type or let upstream package throw error
     if boolean_value:

--- a/webapp/apps/taxbrain/submit_data.py
+++ b/webapp/apps/taxbrain/submit_data.py
@@ -256,6 +256,7 @@ def submit_reform(request, dropq_compute, user=None, json_reform_id=None):
                 use_puf_not_cps,
                 initial=json.loads(personal_inputs.data['raw_input_fields'])
             )
+            personal_inputs.clean() 
             # TODO: parse warnings for file_input
             # only handle GUI errors for now
             if ((taxcalc_errors or taxcalc_warnings) and

--- a/webapp/apps/taxbrain/tests/test_helpers.py
+++ b/webapp/apps/taxbrain/tests/test_helpers.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 import taxcalc
 import pyparsing as pp
-from ..helpers import (rename_keys, json_int_key_encode, INPUT, make_bool,
+from ..helpers import (rename_keys, json_int_key_encode, is_safe, make_bool,
                        is_reverse, reorder_lists)
 from ..param_formatters import parse_value, MetaParam
 from ..param_displayers import TaxCalcParam, nested_form_parameters
@@ -164,22 +164,19 @@ def test_reorder_lists():
      '*', '1,*', '1,*,1,1,*',
      '-2,*', '-7,*,*,2,*',
      'True', 'true', 'TRUE', 'tRue',
-     'False', 'false', 'FALSE', 'faLSe',
+     'False', 'false', 'FALSE','faLSe',
      'true,*', '*, true', '*,*,false',
      'true,*,false,*,*,true',
      '1,*,False', '0.0,True', '1.0,False',
      '<,True', '<,1']
 )
 def test_parsing_pass(item):
-    INPUT.parseString(item)
+    assert is_safe(item)
 
 
-@pytest.mark.parametrize(
-    'item', [
-        'abc', '<,', '<', '1,<', '0,<,1', 'True,<', '-0.002,<,-0.001'])
+@pytest.mark.parametrize('item', ['abc', '01', 'abc,def', '<,abc', '1,abc,2'])
 def test_parsing_fail(item):
-    with pytest.raises(pp.ParseException):
-        INPUT.parseString('abc')
+    assert not is_safe(item)
 
 
 @pytest.mark.parametrize(

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -550,7 +550,8 @@ class TestTaxBrainViews(object):
         ans = get_result_context(tsi, req, url)
         assert ans
 
-    @pytest.mark.parametrize('bad_exp', ['XTOT*4500', 'abc', 'abc,123', '01'])
+    @pytest.mark.parametrize('bad_exp',
+                             ['XTOT*4500', 'abc', 'abc,123', '01', 'a' * 200])
     def test_taxbrain_bad_expression(self, bad_exp):
         """
         POST a bad expression for a TaxBrain parameter and verify that

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -550,7 +550,8 @@ class TestTaxBrainViews(object):
         ans = get_result_context(tsi, req, url)
         assert ans
 
-    def test_taxbrain_bad_expression(self):
+    @pytest.mark.parametrize('bad_exp', ['XTOT*4500', 'abc', 'abc,123', '01'])
+    def test_taxbrain_bad_expression(self, bad_exp):
         """
         POST a bad expression for a TaxBrain parameter and verify that
         it gives an error
@@ -559,13 +560,14 @@ class TestTaxBrainViews(object):
         get_dropq_compute_from_module('webapp.apps.taxbrain.views')
 
         data = get_post_data(START_YEAR, _ID_BenefitSurtax_Switches=False)
-        mod = {'II_brk1_0': ['XTOT*4500'],
+        mod = {'II_brk1_0': [bad_exp],
                'II_brk2_0': ['*, *, 39500']}
         data.update(mod)
 
         response = CLIENT.post('/taxbrain/', data)
         assert response.status_code == 200
         assert response.context['has_errors'] is True
+        assert bad_exp in str(response.context['form'].errors)
 
     @pytest.mark.parametrize('data_source', ['PUF', 'CPS'])
     def test_taxbrain_error_reform_file(self, data_source, bad_reform):

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -105,6 +105,7 @@ def test_meta_param():
      ("EITC_MinEligAge", "22.0", 22),
      ("ID_BenefitCap_Switch_0", "fAlse", False),
      ("ID_Medical_frt_add4aged", "-0.01", -0.01),
+     ("STD_3", "01", "01") 
      ]
 )
 def test_parse_values(name, value, exp, default_params_Policy):


### PR DESCRIPTION
`ast.literal_eval` throws a syntax error in Python 3 when passed a string like `"01"`. In Python 2, `ast.literal_eval` parses this string to `1`. The behavior has been changed to return the original, unparsed value if an exception is thrown. Errors such as this should be caught by the initial input validation logic. The only reason that this occurred is that bad data got through the initial form validation.

Note that there was a bug where the wrong variable was returned and a `NameError` was thrown. This has been fixed.

While working on the issue above, I noticed that the input value validation logic needed some serious work. I spent some time trying to get the `pyparser` library to work as expected, but I was unsuccessful. Thus, I wrote an `is_safe` function that tests:
- how long is the input string?
for each value in a comma separated value string:
- is this value an integer or float?
- is this value a boolean value?
- is this value a reverse character (<)?
- is this value a wildcard character (*)?

Also, this resolves #924